### PR TITLE
Fix possible typo

### DIFF
--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	// run the compiled bytecode
-	// a compiled bytecode 'c' can be executed multiple without re-compiling it
+	// a compiled bytecode 'c' can be executed multiple times without re-compiling it
 	if err := c.Run(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
It looks like there is a typo in one of the comments about compiled bytecode in the documentation.