### PR TITLE
replacing values of the compiled script

### DIFF
--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -70,11 +70,22 @@ func main() {
 
 	// retrieve value of 'a'
 	a := c.Get("a")
-	fmt.Println(a.Int())
+	fmt.Println(a.Int())           // prints "30"
+	
+	// re-run after replacing value of 'b'
+	if err := c.Set("b", 20); err != nil {
+		panic(err)
+	}
+	if err := c.Run(); err != nil {
+		panic(err)
+	}
+	fmt.Println(c.Get("a").Int())  // prints "40"
 }
 ```
 
 A variable `b` is defined by the user before compilation using [Script.Add](https://godoc.org/github.com/d5/tengo/script#Script.Add) function. Then a compiled bytecode `c` is used to execute the bytecode and get the value of global variables. In this example, the value of global variable `a` is read using [Compiled.Get](https://godoc.org/github.com/d5/tengo/script#Compiled.Get) function. See [documentation](https://godoc.org/github.com/d5/tengo/script#Variable) for the full list of variable value functions.
+
+Value of the global variables can be replaced using [Compiled.Set](https://godoc.org/github.com/d5/tengo/script#Compiled.Set) function. But it will return an error if you try to set the value of un-defined global variables _(e.g. trying to set the value of `x` in the example)_.  
 
 ### Type Conversion Table
 

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -80,6 +80,15 @@ func (v *VM) Abort() {
 
 // Run starts the execution.
 func (v *VM) Run() error {
+	// reset VM states
+	v.sp = 0
+	v.curFrame = &(v.frames[0])
+	v.curInsts = v.curFrame.fn.Instructions
+	v.curIPLimit = len(v.curInsts) - 1
+	v.framesIndex = 1
+	v.ip = -1
+	atomic.StoreInt64(&v.aborting, 0)
+
 	for v.ip < v.curIPLimit && (atomic.LoadInt64(&v.aborting) == 0) {
 		v.ip++
 

--- a/script/compiled.go
+++ b/script/compiled.go
@@ -2,6 +2,7 @@ package script
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/d5/tengo/compiler"
 	"github.com/d5/tengo/objects"
@@ -91,4 +92,22 @@ func (c *Compiled) GetAll() []*Variable {
 	}
 
 	return vars
+}
+
+// Set replaces the value of a global variable identified by the name.
+// An error will be returned if the name was not defined during compilation.
+func (c *Compiled) Set(name string, value interface{}) error {
+	obj, err := objects.FromInterface(value)
+	if err != nil {
+		return err
+	}
+
+	symbol, _, ok := c.symbolTable.Resolve(name)
+	if !ok || symbol.Scope != compiler.ScopeGlobal {
+		return fmt.Errorf("'%s' is not defined", name)
+	}
+
+	c.machine.Globals()[symbol.Index] = &obj
+
+	return nil
 }


### PR DESCRIPTION
This change is to allow replacing value of global variables after the script is compiled.

- [x] add `script.Compiled.Set` function so compiled script can replace value of global variables
- [x] fix `VM.Run()` to properly reset its states so it can run multiple times without re-compiling
- [x] update documentation