### PR TITLE
OpBinaryOp to remove redundant code in the VM

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -123,6 +123,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 				return err
 			}
 
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpGreaterThan)
 
 			return nil
@@ -134,6 +135,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 				return err
 			}
 
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpGreaterThanEqual)
 
 			return nil
@@ -148,35 +150,48 @@ func (c *Compiler) Compile(node ast.Node) error {
 
 		switch node.Token {
 		case token.Add:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpAdd)
 		case token.Sub:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpSub)
 		case token.Mul:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpMul)
 		case token.Quo:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpDiv)
 		case token.Rem:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpRem)
 		case token.Greater:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpGreaterThan)
 		case token.GreaterEq:
+			c.emit(node, OpBinaryOp)
 			c.emit(node, OpGreaterThanEqual)
+		case token.And:
+			c.emit(node, OpBinaryOp)
+			c.emit(node, OpBAnd)
+		case token.Or:
+			c.emit(node, OpBinaryOp)
+			c.emit(node, OpBOr)
+		case token.Xor:
+			c.emit(node, OpBinaryOp)
+			c.emit(node, OpBXor)
+		case token.AndNot:
+			c.emit(node, OpBinaryOp)
+			c.emit(node, OpBAndNot)
+		case token.Shl:
+			c.emit(node, OpBinaryOp)
+			c.emit(node, OpBShiftLeft)
+		case token.Shr:
+			c.emit(node, OpBinaryOp)
+			c.emit(node, OpBShiftRight)
 		case token.Equal:
 			c.emit(node, OpEqual)
 		case token.NotEqual:
 			c.emit(node, OpNotEqual)
-		case token.And:
-			c.emit(node, OpBAnd)
-		case token.Or:
-			c.emit(node, OpBOr)
-		case token.Xor:
-			c.emit(node, OpBXor)
-		case token.AndNot:
-			c.emit(node, OpBAndNot)
-		case token.Shl:
-			c.emit(node, OpBShiftLeft)
-		case token.Shr:
-			c.emit(node, OpBShiftRight)
 		default:
 			return c.errorf(node, "invalid binary operator: %s", node.Token.String())
 		}

--- a/compiler/compiler_assign.go
+++ b/compiler/compiler_assign.go
@@ -51,26 +51,37 @@ func (c *Compiler) compileAssign(node ast.Node, lhs, rhs []ast.Expr, op token.To
 
 	switch op {
 	case token.AddAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpAdd)
 	case token.SubAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpSub)
 	case token.MulAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpMul)
 	case token.QuoAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpDiv)
 	case token.RemAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpRem)
 	case token.AndAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpBAnd)
 	case token.OrAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpBOr)
 	case token.AndNotAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpBAndNot)
 	case token.XorAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpBXor)
 	case token.ShlAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpBShiftLeft)
 	case token.ShrAssign:
+		c.emit(node, OpBinaryOp)
 		c.emit(node, OpBShiftRight)
 	}
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -18,6 +18,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -40,6 +41,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpSub),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -51,6 +53,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpMul),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -62,6 +65,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpDiv),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -87,6 +91,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpGreaterThan),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -98,6 +103,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpGreaterThan),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -204,6 +210,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(
@@ -219,6 +226,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiler.MakeInstruction(compiler.OpSetGlobal, 1),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpSetGlobal, 0)),
 			objectsArray(
@@ -234,6 +242,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiler.MakeInstruction(compiler.OpSetGlobal, 1),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpDiv),
 				compiler.MakeInstruction(compiler.OpSetGlobal, 0)),
 			objectsArray(
@@ -265,12 +274,15 @@ func TestCompiler_Compile(t *testing.T) {
 			concat(
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpConstant, 2),
 				compiler.MakeInstruction(compiler.OpConstant, 3),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpSub),
 				compiler.MakeInstruction(compiler.OpConstant, 4),
 				compiler.MakeInstruction(compiler.OpConstant, 5),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpMul),
 				compiler.MakeInstruction(compiler.OpArray, 3),
 				compiler.MakeInstruction(compiler.OpPop)),
@@ -314,10 +326,12 @@ func TestCompiler_Compile(t *testing.T) {
 				compiler.MakeInstruction(compiler.OpConstant, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
 				compiler.MakeInstruction(compiler.OpConstant, 2),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpConstant, 3),
 				compiler.MakeInstruction(compiler.OpConstant, 4),
 				compiler.MakeInstruction(compiler.OpConstant, 5),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpMul),
 				compiler.MakeInstruction(compiler.OpMap, 4),
 				compiler.MakeInstruction(compiler.OpPop)),
@@ -338,6 +352,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiler.MakeInstruction(compiler.OpArray, 3),
 				compiler.MakeInstruction(compiler.OpConstant, 3),
 				compiler.MakeInstruction(compiler.OpConstant, 4),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpIndex),
 				compiler.MakeInstruction(compiler.OpPop)),
@@ -356,6 +371,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiler.MakeInstruction(compiler.OpMap, 2),
 				compiler.MakeInstruction(compiler.OpConstant, 2),
 				compiler.MakeInstruction(compiler.OpConstant, 3),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpSub),
 				compiler.MakeInstruction(compiler.OpIndex),
 				compiler.MakeInstruction(compiler.OpPop)),
@@ -444,6 +460,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiledFunction(0, 0,
 					compiler.MakeInstruction(compiler.OpConstant, 0),
 					compiler.MakeInstruction(compiler.OpConstant, 1),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpReturnValue)))))
 
@@ -458,6 +475,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiledFunction(0, 0,
 					compiler.MakeInstruction(compiler.OpConstant, 0),
 					compiler.MakeInstruction(compiler.OpConstant, 1),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpPop),
 					compiler.MakeInstruction(compiler.OpReturn)))))
@@ -636,6 +654,7 @@ func TestCompiler_Compile(t *testing.T) {
 					compiler.MakeInstruction(compiler.OpDefineLocal, 1),
 					compiler.MakeInstruction(compiler.OpGetLocal, 0),
 					compiler.MakeInstruction(compiler.OpGetLocal, 1),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpReturnValue)))))
 
@@ -722,6 +741,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiledFunction(1, 1,
 					compiler.MakeInstruction(compiler.OpGetFree, 0),
 					compiler.MakeInstruction(compiler.OpGetLocal, 0),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpReturnValue)),
 				compiledFunction(1, 1,
@@ -731,10 +751,10 @@ func TestCompiler_Compile(t *testing.T) {
 					compiler.MakeInstruction(compiler.OpReturn)))))
 
 	expect(t, `
-func(a) { 
-	return func(b) { 
-		return func(c) { 
-			return a + b + c 
+func(a) {
+	return func(b) {
+		return func(c) {
+			return a + b + c
 		}
 	}
 }`,
@@ -746,8 +766,10 @@ func(a) {
 				compiledFunction(1, 1,
 					compiler.MakeInstruction(compiler.OpGetFree, 0),
 					compiler.MakeInstruction(compiler.OpGetFree, 1),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpGetLocal, 0),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpReturnValue)),
 				compiledFunction(1, 1,
@@ -792,10 +814,13 @@ func() {
 					compiler.MakeInstruction(compiler.OpDefineLocal, 0),
 					compiler.MakeInstruction(compiler.OpGetGlobal, 0),
 					compiler.MakeInstruction(compiler.OpGetFree, 0),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpGetFree, 1),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpGetLocal, 0),
+					compiler.MakeInstruction(compiler.OpBinaryOp),
 					compiler.MakeInstruction(compiler.OpAdd),
 					compiler.MakeInstruction(compiler.OpReturnValue)),
 				compiledFunction(1, 0,
@@ -819,10 +844,12 @@ func() {
 				compiler.MakeInstruction(compiler.OpSetGlobal, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 1),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpGreaterThan),
-				compiler.MakeInstruction(compiler.OpJumpFalsy, 29),
+				compiler.MakeInstruction(compiler.OpJumpFalsy, 31),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 2),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpAdd),
 				compiler.MakeInstruction(compiler.OpSetGlobal, 0),
 				compiler.MakeInstruction(compiler.OpJump, 6)),
@@ -863,9 +890,10 @@ func() {
 				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
 				compiler.MakeInstruction(compiler.OpConstant, 2),
 				compiler.MakeInstruction(compiler.OpNotEqual),
-				compiler.MakeInstruction(compiler.OpOrJump, 33),
+				compiler.MakeInstruction(compiler.OpOrJump, 34),
 				compiler.MakeInstruction(compiler.OpConstant, 3),
 				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
+				compiler.MakeInstruction(compiler.OpBinaryOp),
 				compiler.MakeInstruction(compiler.OpGreaterThan),
 				compiler.MakeInstruction(compiler.OpPop)),
 			objectsArray(

--- a/compiler/opcodes.go
+++ b/compiler/opcodes.go
@@ -58,6 +58,7 @@ const (
 	OpIteratorNext                   // Iterator next
 	OpIteratorKey                    // Iterator key
 	OpIteratorValue                  // Iterator value
+	OpBinaryOp                       // Binary operation
 )
 
 // OpcodeNames is opcode names.
@@ -115,6 +116,7 @@ var OpcodeNames = [...]string{
 	OpIteratorNext:     "ITNXT",
 	OpIteratorKey:      "ITKEY",
 	OpIteratorValue:    "ITVAL",
+	OpBinaryOp:         "BINARYOP",
 }
 
 // OpcodeOperands is the number of operands.
@@ -172,6 +174,7 @@ var OpcodeOperands = [...][]int{
 	OpIteratorNext:     {},
 	OpIteratorKey:      {},
 	OpIteratorValue:    {},
+	OpBinaryOp:         {},
 }
 
 // ReadOperands reads operands from the bytecode.


### PR DESCRIPTION
This is what I was talking about yesterday. The `OpBinaryOp` is just a placeholder that removes the necessity of all the redundant code for each operation that calls Object.BinaryOp().

While this is possible to do as `case compiler.OpAdd, compiler.OpSub, compiler.OpMul, ...`, that ends up reducing performance of `fib(35)` recursive by about 1-2% whereas the `OpBinaryOp` version is slightly (negligibly) faster than the duplicated code. 