### PR TITLE
Fixed panic when bailout is triggered in parser.ParseFile()

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -875,6 +875,22 @@ func() {
 				intObject(1))))
 
 	expectError(t, `import("user1")`, "no such file or directory") // unknown module name
+
+	expectError(t, `
+r["x"] = {
+    "a":1,
+    "b":1,
+    "c":1,
+    "d":1,
+    "e":1,
+    "f":1,
+    "g":1,
+    "h":1,
+    "i":1,
+    "j":1,
+    "k":1,
+}
+`, "Parse Error: expected 'IDENT', found \"a\"\n\tat test:3:5 (and 10 more errors)") // too many errors
 }
 
 func concat(instructions ...[]byte) []byte {

--- a/script/script.go
+++ b/script/script.go
@@ -92,7 +92,7 @@ func (s *Script) Compile() (*Compiled, error) {
 	p := parser.NewParser(srcFile, s.input, nil)
 	file, err := p.ParseFile()
 	if err != nil {
-		return nil, fmt.Errorf("parse error: %s", err.Error())
+		return nil, err
 	}
 
 	c := compiler.NewCompiler(srcFile, symbolTable, nil, stdModules, nil)


### PR DESCRIPTION
Bailout shouldn't cause panic but return errors as in parser/parse_file.go