### PR TITLE
String keys allowed for map definitions.

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -878,19 +878,19 @@ func() {
 
 	expectError(t, `
 r["x"] = {
-    "a":1,
-    "b":1,
-    "c":1,
-    "d":1,
-    "e":1,
-    "f":1,
-    "g":1,
-    "h":1,
-    "i":1,
-    "j":1,
-    "k":1,
+    @a:1,
+    @b:1,
+    @c:1,
+    @d:1,
+    @e:1,
+    @f:1,
+    @g:1,
+    @h:1,
+    @i:1,
+    @j:1,
+    @k:1
 }
-`, "Parse Error: expected 'IDENT', found \"a\"\n\tat test:3:5 (and 10 more errors)") // too many errors
+`, "Parse Error: illegal character U+0040 '@'\n\tat test:3:5 (and 10 more errors)") // too many errors
 }
 
 func concat(instructions ...[]byte) []byte {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -1016,15 +1016,27 @@ func (p *Parser) parseMapElementLit() *ast.MapElementLit {
 	}
 
 	// key: read identifier token but it's not actually an identifier
-	ident := p.parseIdent()
+	pos := p.pos
+	name := "_"
+
+	if p.token == token.Ident {
+		name = p.tokenLit
+		p.next()
+	} else if p.token == token.String {
+		v, _ := strconv.Unquote(p.tokenLit)
+		name = v
+		p.next()
+	} else {
+		p.expect(token.Ident)
+	}
 
 	colonPos := p.expect(token.Colon)
 
 	valueExpr := p.parseExpr()
 
 	return &ast.MapElementLit{
-		Key:      ident.Name,
-		KeyPos:   ident.NamePos,
+		Key:      name,
+		KeyPos:   pos,
 		ColonPos: colonPos,
 		Value:    valueExpr,
 	}

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -1015,23 +1015,21 @@ func (p *Parser) parseMapElementLit() *ast.MapElementLit {
 		defer un(trace(p, "MapElementLit"))
 	}
 
-	// key: read identifier token but it's not actually an identifier
 	pos := p.pos
 	name := "_"
 
 	if p.token == token.Ident {
 		name = p.tokenLit
-		p.next()
 	} else if p.token == token.String {
 		v, _ := strconv.Unquote(p.tokenLit)
 		name = v
-		p.next()
 	} else {
-		p.expect(token.Ident)
+		p.errorExpected(pos, "map key")
 	}
 
-	colonPos := p.expect(token.Colon)
+	p.next()
 
+	colonPos := p.expect(token.Colon)
 	valueExpr := p.parseExpr()
 
 	return &ast.MapElementLit{

--- a/compiler/parser/parser_map_test.go
+++ b/compiler/parser/parser_map_test.go
@@ -17,6 +17,13 @@ func TestMap(t *testing.T) {
 					mapElementLit("key3", p(1, 23), p(1, 27), boolLit(true, p(1, 29))))))
 	})
 
+	expect(t, "{ \"key1\": 1 }", func(p pfn) []ast.Stmt {
+		return stmts(
+			exprStmt(
+				mapLit(p(1, 1), p(1, 13),
+					mapElementLit("key1", p(1, 3), p(1, 9), intLit(1, p(1, 11))))))
+	})
+
 	expect(t, "a = { key1: 1, key2: \"2\", key3: true }", func(p pfn) []ast.Stmt {
 		return stmts(
 			assignStmt(
@@ -46,8 +53,8 @@ func TestMap(t *testing.T) {
 
 	expect(t, `
 {
-	key1: 1, 
-	key2: "2", 
+	key1: 1,
+	key2: "2",
 	key3: true
 }`, func(p pfn) []ast.Stmt {
 		return stmts(

--- a/runtime/vm_map_test.go
+++ b/runtime/vm_map_test.go
@@ -18,6 +18,17 @@ out = {
 		"three": 3,
 	})
 
+	expect(t, `
+out = {
+	"one": 10 - 9,
+	"two": 1 + 1,
+	"three": 6 / 2
+}`, MAP{
+		"one":   1,
+		"two":   2,
+		"three": 3,
+	})
+
 	expect(t, `out = {foo: 5}["foo"]`, 5)
 	expect(t, `out = {foo: 5}["bar"]`, objects.UndefinedValue)
 	expect(t, `key := "foo"; out = {foo: 5}[key]`, 5)


### PR DESCRIPTION
#114 

One comment:
p.expects allows only one token and I'm not sure whether token.Ident would be the best option, but I have left it as is for now.