### PR TITLE
script.Add accepts a CallableFunc value

### DIFF
--- a/objects/conversion.go
+++ b/objects/conversion.go
@@ -243,6 +243,10 @@ func FromInterface(v interface{}) (Object, error) {
 		return &Time{Value: v}, nil
 	case Object:
 		return v, nil
+	case CallableFunc:
+		return &UserFunction{Value: v}, nil
+	case func(...Object) (Object, error):
+		return &UserFunction{Value: v}, nil
 	}
 
 	return nil, fmt.Errorf("cannot convert to object: %T", v)

--- a/script/script.go
+++ b/script/script.go
@@ -33,6 +33,16 @@ func New(input []byte) *Script {
 func (s *Script) Add(name string, value interface{}) error {
 	obj, err := objects.FromInterface(value)
 	if err != nil {
+		switch v := value.(type) {
+		case objects.CallableFunc:
+			obj = &objects.UserFunction{Value: v}
+			err = nil
+		case func(...objects.Object) (objects.Object, error):
+			obj = &objects.UserFunction{Value: v}
+			err = nil
+		}
+	}
+	if err != nil {
 		return err
 	}
 

--- a/script/script.go
+++ b/script/script.go
@@ -33,16 +33,6 @@ func New(input []byte) *Script {
 func (s *Script) Add(name string, value interface{}) error {
 	obj, err := objects.FromInterface(value)
 	if err != nil {
-		switch v := value.(type) {
-		case objects.CallableFunc:
-			obj = &objects.UserFunction{Value: v}
-			err = nil
-		case func(...objects.Object) (objects.Object, error):
-			obj = &objects.UserFunction{Value: v}
-			err = nil
-		}
-	}
-	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
fixes #77 

I've the conversion in scripts.Add instead of objects.FromInterface as it is not clear that objects.FromInterface will never be called for builtins.