### PR TITLE
add module-import tests to most of runtime package

### DIFF
--- a/objects/callable_func.go
+++ b/objects/callable_func.go
@@ -1,4 +1,4 @@
 package objects
 
 // CallableFunc is a function signature for the callable functions.
-type CallableFunc func(args ...Object) (ret Object, err error)
+type CallableFunc = func(args ...Object) (ret Object, err error)

--- a/objects/conversion.go
+++ b/objects/conversion.go
@@ -253,8 +253,6 @@ func FromInterface(v interface{}) (Object, error) {
 		return v, nil
 	case CallableFunc:
 		return &UserFunction{Value: v}, nil
-	case func(...Object) (Object, error):
-		return &UserFunction{Value: v}, nil
 	}
 
 	return nil, fmt.Errorf("cannot convert to object: %T", v)

--- a/runtime/vm_cond_test.go
+++ b/runtime/vm_cond_test.go
@@ -11,6 +11,7 @@ func TestCondExpr(t *testing.T) {
 	expect(t, `out = (1 == 1) ? false ? 10 - 8 : 1 + 3 : 12 - 2`, 4)
 
 	expect(t, `
+out = 0
 f1 := func() { out += 10 }
 f2 := func() { out = -out }
 true ? f1() : f2()

--- a/runtime/vm_for_in_test.go
+++ b/runtime/vm_for_in_test.go
@@ -6,20 +6,20 @@ import (
 
 func TestForIn(t *testing.T) {
 	// array
-	expect(t, `for x in [1, 2, 3] { out += x }`, 6)                     // value
-	expect(t, `for i, x in [1, 2, 3] { out += i + x }`, 9)              // index, value
-	expect(t, `func() { for i, x in [1, 2, 3] { out += i + x } }()`, 9) // index, value
-	expect(t, `for i, _ in [1, 2, 3] { out += i }`, 3)                  // index, _
-	expect(t, `func() { for i, _ in [1, 2, 3] { out += i  } }()`, 3)    // index, _
+	expect(t, `out = 0; for x in [1, 2, 3] { out += x }`, 6)                     // value
+	expect(t, `out = 0; for i, x in [1, 2, 3] { out += i + x }`, 9)              // index, value
+	expect(t, `out = 0; func() { for i, x in [1, 2, 3] { out += i + x } }()`, 9) // index, value
+	expect(t, `out = 0; for i, _ in [1, 2, 3] { out += i }`, 3)                  // index, _
+	expect(t, `out = 0; func() { for i, _ in [1, 2, 3] { out += i  } }()`, 3)    // index, _
 
 	// map
-	expect(t, `for v in {a:2,b:3,c:4} { out += v }`, 9)                                     // value
-	expect(t, `for k, v in {a:2,b:3,c:4} { out = k; if v==3 { break } }`, "b")              // key, value
-	expect(t, `for k, _ in {a:2} { out += k }`, "a")                                        // key, _
-	expect(t, `for _, v in {a:2,b:3,c:4} { out += v }`, 9)                                  // _, value
-	expect(t, `func() { for k, v in {a:2,b:3,c:4} { out = k; if v==3 { break } } }()`, "b") // key, value
+	expect(t, `out = 0; for v in {a:2,b:3,c:4} { out += v }`, 9)                                      // value
+	expect(t, `out = ""; for k, v in {a:2,b:3,c:4} { out = k; if v==3 { break } }`, "b")              // key, value
+	expect(t, `out = ""; for k, _ in {a:2} { out += k }`, "a")                                        // key, _
+	expect(t, `out = 0; for _, v in {a:2,b:3,c:4} { out += v }`, 9)                                   // _, value
+	expect(t, `out = ""; func() { for k, v in {a:2,b:3,c:4} { out = k; if v==3 { break } } }()`, "b") // key, value
 
 	// string
-	expect(t, `for c in "abcde" { out += c }`, "abcde")
-	expect(t, `for i, c in "abcde" { if i == 2 { continue }; out += c }`, "abde")
+	expect(t, `out = ""; for c in "abcde" { out += c }`, "abcde")
+	expect(t, `out = ""; for i, c in "abcde" { if i == 2 { continue }; out += c }`, "abde")
 }

--- a/runtime/vm_for_test.go
+++ b/runtime/vm_for_test.go
@@ -6,6 +6,7 @@ import (
 
 func TestFor(t *testing.T) {
 	expect(t, `
+	out = 0
 	for {
 		out++
 		if out == 5 {
@@ -14,6 +15,7 @@ func TestFor(t *testing.T) {
 	}`, 5)
 
 	expect(t, `
+	out = 0
 	for {
 		out++
 		if out == 5 {
@@ -22,6 +24,7 @@ func TestFor(t *testing.T) {
 	}`, 5)
 
 	expect(t, `
+	out = 0
 	a := 0
 	for {
 		a++
@@ -31,6 +34,7 @@ func TestFor(t *testing.T) {
 	}`, 7) // 1 + 2 + 4
 
 	expect(t, `
+	out = 0
 	a := 0
 	for {
 		a++
@@ -40,6 +44,7 @@ func TestFor(t *testing.T) {
 	}`, 12) // 1 + 2 + 4 + 5
 
 	expect(t, `
+	out = 0
 	for true {
 		out++
 		if out == 5 {
@@ -58,6 +63,7 @@ func TestFor(t *testing.T) {
 	out = a`, 5)
 
 	expect(t, `
+	out = 0
 	a := 0
 	for true {
 		a++
@@ -67,6 +73,7 @@ func TestFor(t *testing.T) {
 	}`, 7) // 1 + 2 + 4
 
 	expect(t, `
+	out = 0
 	a := 0
 	for true {
 		a++
@@ -76,6 +83,7 @@ func TestFor(t *testing.T) {
 	}`, 12) // 1 + 2 + 4 + 5
 
 	expect(t, `
+	out = 0
 	func() {
 		for true {
 			out++
@@ -86,11 +94,13 @@ func TestFor(t *testing.T) {
 	}()`, 5)
 
 	expect(t, `
+	out = 0
 	for a:=1; a<=10; a++ {
 		out += a
 	}`, 55)
 
 	expect(t, `
+	out = 0
 	for a:=1; a<=3; a++ {
 		for b:=3; b<=6; b++ {
 			out += b
@@ -98,6 +108,7 @@ func TestFor(t *testing.T) {
 	}`, 54)
 
 	expect(t, `
+	out = 0
 	func() {
 		for {
 			out++
@@ -108,6 +119,7 @@ func TestFor(t *testing.T) {
 	}()`, 5)
 
 	expect(t, `
+	out = 0
 	func() {
 		for true {
 			out++
@@ -199,6 +211,7 @@ func TestFor(t *testing.T) {
 	out = a`, 5)
 
 	expect(t, `
+	out = 0
 	for a:=1; a<=10; a++ {
 		if a == 3 {
 			continue
@@ -210,6 +223,7 @@ func TestFor(t *testing.T) {
 	}`, 12) // 1 + 2 + 4 + 5
 
 	expect(t, `
+	out = 0
 	for a:=1; a<=10; {
 		if a == 3 {
 			a++

--- a/runtime/vm_inc_dec_test.go
+++ b/runtime/vm_inc_dec_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestIncDec(t *testing.T) {
-	expect(t, `out++`, 1)
-	expect(t, `out--`, -1)
+	expect(t, `out = 0; out++`, 1)
+	expect(t, `out = 0; out--`, -1)
 	expect(t, `a := 0; a++; out = a`, 1)
 	expect(t, `a := 0; a++; a--; out = a`, 0)
 

--- a/runtime/vm_module_test.go
+++ b/runtime/vm_module_test.go
@@ -193,7 +193,7 @@ export func() {
 	})
 
 	// 'export' statement is ignored outside module
-	expect(t, `a := 5; export func() { a = 10 }(); out = a`, 5)
+	expectNoMod(t, `a := 5; export func() { a = 10 }(); out = a`, 5)
 
 	// 'export' must be in the top-level
 	expectErrorWithUserModules(t, `import("mod1")`, map[string]string{


### PR DESCRIPTION
- [x] tests in runtime package are tested in 2-pass: the first pass is to test the code as-is, and, the second pass is to test the code as an imported module
  - [x] and some cleanups
- [x] `CallableFunc` is now a type alias: `type CallableFunc = func(args ...Object) (ret Object, err error)` 
