### PR TITLE
fix bytecode encoding/decoding of builtin modules

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -168,15 +168,8 @@ func CompileAndRun(modules map[string]objects.Importable, data []byte, inputFile
 
 // RunCompiled reads the compiled binary from file and executes it.
 func RunCompiled(modules map[string]objects.Importable, data []byte) (err error) {
-	builtinModules := make(map[string]*objects.BuiltinModule)
-	for name, mod := range modules {
-		if builtinMod, ok := mod.(*objects.BuiltinModule); ok {
-			builtinModules[name] = builtinMod
-		}
-	}
-
 	bytecode := &compiler.Bytecode{}
-	err = bytecode.Decode(bytes.NewReader(data), builtinModules)
+	err = bytecode.Decode(bytes.NewReader(data), modules)
 	if err != nil {
 		return
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -41,7 +41,7 @@ type Options struct {
 	Version string
 
 	// Import modules
-	Modules map[string]objects.Importable
+	Modules *objects.ModuleMap
 }
 
 // Run CLI
@@ -117,7 +117,7 @@ func doHelp() {
 }
 
 // CompileOnly compiles the source code and writes the compiled binary into outputFile.
-func CompileOnly(modules map[string]objects.Importable, data []byte, inputFile, outputFile string) (err error) {
+func CompileOnly(modules *objects.ModuleMap, data []byte, inputFile, outputFile string) (err error) {
 	bytecode, err := compileSrc(modules, data, filepath.Base(inputFile))
 	if err != nil {
 		return
@@ -150,7 +150,7 @@ func CompileOnly(modules map[string]objects.Importable, data []byte, inputFile, 
 }
 
 // CompileAndRun compiles the source code and executes it.
-func CompileAndRun(modules map[string]objects.Importable, data []byte, inputFile string) (err error) {
+func CompileAndRun(modules *objects.ModuleMap, data []byte, inputFile string) (err error) {
 	bytecode, err := compileSrc(modules, data, filepath.Base(inputFile))
 	if err != nil {
 		return
@@ -167,7 +167,7 @@ func CompileAndRun(modules map[string]objects.Importable, data []byte, inputFile
 }
 
 // RunCompiled reads the compiled binary from file and executes it.
-func RunCompiled(modules map[string]objects.Importable, data []byte) (err error) {
+func RunCompiled(modules *objects.ModuleMap, data []byte) (err error) {
 	bytecode := &compiler.Bytecode{}
 	err = bytecode.Decode(bytes.NewReader(data), modules)
 	if err != nil {
@@ -185,7 +185,7 @@ func RunCompiled(modules map[string]objects.Importable, data []byte) (err error)
 }
 
 // RunREPL starts REPL.
-func RunREPL(modules map[string]objects.Importable, in io.Reader, out io.Writer) {
+func RunREPL(modules *objects.ModuleMap, in io.Reader, out io.Writer) {
 	stdin := bufio.NewScanner(in)
 
 	fileSet := source.NewFileSet()
@@ -258,7 +258,7 @@ func RunREPL(modules map[string]objects.Importable, in io.Reader, out io.Writer)
 	}
 }
 
-func compileSrc(modules map[string]objects.Importable, src []byte, filename string) (*compiler.Bytecode, error) {
+func compileSrc(modules *objects.ModuleMap, src []byte, filename string) (*compiler.Bytecode, error) {
 	fileSet := source.NewFileSet()
 	srcFile := fileSet.AddFile(filename, -1, len(src))
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -37,7 +37,7 @@ file.write_string("random number is " + rand_num())
 file.close()
 `)
 
-	mods := stdlib.GetModules(stdlib.AllModuleNames()...)
+	mods := stdlib.GetModuleMap(stdlib.AllModuleNames()...)
 
 	err := cli.CompileOnly(mods, src, "src", binFile)
 	if !assert.NoError(t, err) {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,64 @@
+package cli_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/d5/tengo/assert"
+	"github.com/d5/tengo/cli"
+	"github.com/d5/tengo/stdlib"
+)
+
+func TestCLICompileAndRun(t *testing.T) {
+	tempDir := filepath.Join(os.TempDir(), "tengo_tests")
+	_ = os.MkdirAll(tempDir, os.ModePerm)
+	binFile := filepath.Join(tempDir, "cli_bin")
+	outFile := filepath.Join(tempDir, "cli_out")
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	src := []byte(`
+os := import("os")
+rand := import("rand")
+times := import("times")
+
+rand.seed(times.time_nanosecond(times.now()))
+
+rand_num := func() {
+	return rand.intn(100)
+}
+
+file := os.create("` + outFile + `")
+file.write_string("random number is " + rand_num())
+file.close()
+`)
+
+	mods := stdlib.GetModules(stdlib.AllModuleNames()...)
+
+	err := cli.CompileOnly(mods, src, "src", binFile)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	compiledBin, err := ioutil.ReadFile(binFile)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = cli.RunCompiled(mods, compiledBin)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	read, err := ioutil.ReadFile(outFile)
+	if !assert.NoError(t, err) {
+		return
+	}
+	ok, err := regexp.Match(`^random number is \d+$`, read)
+	assert.NoError(t, err)
+	assert.True(t, ok, string(read))
+}

--- a/cmd/tengo/main.go
+++ b/cmd/tengo/main.go
@@ -27,7 +27,7 @@ func main() {
 		ShowVersion:   showVersion,
 		Version:       version,
 		CompileOutput: compileOutput,
-		Modules:       stdlib.GetModules(stdlib.AllModuleNames()...),
+		Modules:       stdlib.GetModuleMap(stdlib.AllModuleNames()...),
 		InputFile:     flag.Arg(0),
 	})
 }

--- a/compiler/bytecode_decode.go
+++ b/compiler/bytecode_decode.go
@@ -2,13 +2,14 @@ package compiler
 
 import (
 	"encoding/gob"
+	"fmt"
 	"io"
 
 	"github.com/d5/tengo/objects"
 )
 
 // Decode reads Bytecode data from the reader.
-func (b *Bytecode) Decode(r io.Reader) error {
+func (b *Bytecode) Decode(r io.Reader, builtinModules map[string]*objects.BuiltinModule) error {
 	dec := gob.NewDecoder(r)
 
 	if err := dec.Decode(&b.FileSet); err != nil {
@@ -25,38 +26,68 @@ func (b *Bytecode) Decode(r io.Reader) error {
 		return err
 	}
 	for i, v := range b.Constants {
-		b.Constants[i] = fixDecoded(v)
+		fv, err := fixDecoded(v, builtinModules)
+		if err != nil {
+			return err
+		}
+		b.Constants[i] = fv
 	}
 
 	return nil
 }
 
-func fixDecoded(o objects.Object) objects.Object {
+func fixDecoded(o objects.Object, builtinModules map[string]*objects.BuiltinModule) (objects.Object, error) {
 	switch o := o.(type) {
 	case *objects.Bool:
 		if o.IsFalsy() {
-			return objects.FalseValue
+			return objects.FalseValue, nil
 		}
-		return objects.TrueValue
+		return objects.TrueValue, nil
 	case *objects.Undefined:
-		return objects.UndefinedValue
+		return objects.UndefinedValue, nil
 	case *objects.Array:
 		for i, v := range o.Value {
-			o.Value[i] = fixDecoded(v)
+			fv, err := fixDecoded(v, builtinModules)
+			if err != nil {
+				return nil, err
+			}
+			o.Value[i] = fv
 		}
 	case *objects.ImmutableArray:
 		for i, v := range o.Value {
-			o.Value[i] = fixDecoded(v)
+			fv, err := fixDecoded(v, builtinModules)
+			if err != nil {
+				return nil, err
+			}
+			o.Value[i] = fv
 		}
 	case *objects.Map:
 		for k, v := range o.Value {
-			o.Value[k] = fixDecoded(v)
+			fv, err := fixDecoded(v, builtinModules)
+			if err != nil {
+				return nil, err
+			}
+			o.Value[k] = fv
 		}
 	case *objects.ImmutableMap:
+		modName := moduleName(o)
+		if mod, ok := builtinModules[modName]; ok {
+			return mod.AsImmutableMap(), nil
+		}
+
 		for k, v := range o.Value {
-			o.Value[k] = fixDecoded(v)
+			// encoding of user function not supported
+			if _, isUserFunction := v.(*objects.UserFunction); isUserFunction {
+				return nil, fmt.Errorf("user function not decodable")
+			}
+
+			fv, err := fixDecoded(v, builtinModules)
+			if err != nil {
+				return nil, err
+			}
+			o.Value[k] = fv
 		}
 	}
 
-	return o
+	return o, nil
 }

--- a/compiler/bytecode_decode.go
+++ b/compiler/bytecode_decode.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Decode reads Bytecode data from the reader.
-func (b *Bytecode) Decode(r io.Reader, builtinModules map[string]*objects.BuiltinModule) error {
+func (b *Bytecode) Decode(r io.Reader, builtinModules map[string]objects.Importable) error {
 	dec := gob.NewDecoder(r)
 
 	if err := dec.Decode(&b.FileSet); err != nil {
@@ -36,7 +36,7 @@ func (b *Bytecode) Decode(r io.Reader, builtinModules map[string]*objects.Builti
 	return nil
 }
 
-func fixDecoded(o objects.Object, builtinModules map[string]*objects.BuiltinModule) (objects.Object, error) {
+func fixDecoded(o objects.Object, builtinModules map[string]objects.Importable) (objects.Object, error) {
 	switch o := o.(type) {
 	case *objects.Bool:
 		if o.IsFalsy() {
@@ -71,7 +71,7 @@ func fixDecoded(o objects.Object, builtinModules map[string]*objects.BuiltinModu
 		}
 	case *objects.ImmutableMap:
 		modName := moduleName(o)
-		if mod, ok := builtinModules[modName]; ok {
+		if mod, ok := builtinModules[modName].(*objects.BuiltinModule); ok {
 			return mod.AsImmutableMap(), nil
 		}
 

--- a/compiler/bytecode_test.go
+++ b/compiler/bytecode_test.go
@@ -280,7 +280,7 @@ func testBytecodeSerialization(t *testing.T, b *compiler.Bytecode) {
 	assert.NoError(t, err)
 
 	r := &compiler.Bytecode{}
-	err = r.Decode(bytes.NewReader(buf.Bytes()))
+	err = r.Decode(bytes.NewReader(buf.Bytes()), nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, b.FileSet, r.FileSet)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -514,7 +514,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 		}
 
 		if mod, ok := c.importModules[node.ModuleName]; ok {
-			v, err := mod.Import(node.ModuleName)
+			v, err := mod.Import()
 			if err != nil {
 				return err
 			}

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -119,17 +119,13 @@ Users can add and use a custom user type in Tengo code by implementing [Object](
 
 To securely compile and execute _potentially_ unsafe script code, you can use the following Script functions.
 
-#### Script.SetImports(modules map[string]objects.Importable)
+#### Script.SetImports(modules *objects.ModuleMap)
 
 SetImports sets the import modules with corresponding names. Script **does not** include any modules by default. You can use this function to include the [Standard Library](https://github.com/d5/tengo/blob/master/docs/stdlib.md).
 
 ```golang
 s := script.New([]byte(`math := import("math"); a := math.abs(-19.84)`))
 
-s.SetImports(map[string]objects.Importable{
-    "math": stdlib.BuiltinModules["math"],
-})
-// or
 s.SetImports(stdlib.GetModules("math"))
 // or, to include all stdlib at once
 s.SetImports(stdlib.GetModules(stdlib.AllModuleNames()...))
@@ -140,9 +136,9 @@ You can also include Tengo's written module using `objects.SourceModule` (which 
 ```golang
 s := script.New([]byte(`double := import("double"); a := double(20)`))
 
-s.SetImports(map[string]objects.Importable{
-    "double": &objects.SourceModule{Src: []byte(`export func(x) { return x * 2 }`)},
-})
+mods := objects.NewModuleMap()
+mods.AddSourceModule("double", []byte(`export func(x) { return x * 2 }`))
+s.SetImports(mods)
 ```
 
 

--- a/objects/builtin_module.go
+++ b/objects/builtin_module.go
@@ -2,25 +2,22 @@ package objects
 
 // BuiltinModule is an importable module that's written in Go.
 type BuiltinModule struct {
-	Name  string
 	Attrs map[string]Object
 }
 
 // Import returns an immutable map for the module.
-func (m *BuiltinModule) Import() (interface{}, error) {
-	return m.AsImmutableMap(), nil
+func (m *BuiltinModule) Import(moduleName string) (interface{}, error) {
+	return m.AsImmutableMap(moduleName), nil
 }
 
 // AsImmutableMap converts builtin module into an immutable map.
-func (m *BuiltinModule) AsImmutableMap() *ImmutableMap {
+func (m *BuiltinModule) AsImmutableMap(moduleName string) *ImmutableMap {
 	attrs := make(map[string]Object, len(m.Attrs))
 	for k, v := range m.Attrs {
 		attrs[k] = v.Copy()
 	}
 
-	if m.Name != "" {
-		attrs["__module_name__"] = &String{Value: m.Name}
-	}
+	attrs["__module_name__"] = &String{Value: moduleName}
 
 	return &ImmutableMap{Value: attrs}
 }

--- a/objects/builtin_module.go
+++ b/objects/builtin_module.go
@@ -2,15 +2,25 @@ package objects
 
 // BuiltinModule is an importable module that's written in Go.
 type BuiltinModule struct {
+	Name  string
 	Attrs map[string]Object
 }
 
 // Import returns an immutable map for the module.
-func (m *BuiltinModule) Import(name string) (interface{}, error) {
+func (m *BuiltinModule) Import() (interface{}, error) {
+	return m.AsImmutableMap(), nil
+}
+
+// AsImmutableMap converts builtin module into an immutable map.
+func (m *BuiltinModule) AsImmutableMap() *ImmutableMap {
 	attrs := make(map[string]Object, len(m.Attrs))
 	for k, v := range m.Attrs {
 		attrs[k] = v.Copy()
 	}
-	attrs["__module_name__"] = &String{Value: name}
-	return &ImmutableMap{Value: attrs}, nil
+
+	if m.Name != "" {
+		attrs["__module_name__"] = &String{Value: m.Name}
+	}
+
+	return &ImmutableMap{Value: attrs}
 }

--- a/objects/importable.go
+++ b/objects/importable.go
@@ -3,5 +3,5 @@ package objects
 // Importable interface represents importable module instance.
 type Importable interface {
 	// Import should return either an Object or module source code ([]byte).
-	Import(name string) (interface{}, error)
+	Import() (interface{}, error)
 }

--- a/objects/importable.go
+++ b/objects/importable.go
@@ -3,5 +3,5 @@ package objects
 // Importable interface represents importable module instance.
 type Importable interface {
 	// Import should return either an Object or module source code ([]byte).
-	Import() (interface{}, error)
+	Import(moduleName string) (interface{}, error)
 }

--- a/objects/module_map.go
+++ b/objects/module_map.go
@@ -1,0 +1,65 @@
+package objects
+
+// ModuleMap represents a set of named modules.
+// Use NewModuleMap to create a new module map.
+type ModuleMap struct {
+	m map[string]Importable
+}
+
+// NewModuleMap creates a new module map.
+func NewModuleMap() *ModuleMap {
+	return &ModuleMap{
+		m: make(map[string]Importable),
+	}
+}
+
+// Add adds an import module.
+func (m *ModuleMap) Add(name string, module Importable) {
+	m.m[name] = module
+}
+
+// AddBuiltinModule adds a builtin module.
+func (m *ModuleMap) AddBuiltinModule(name string, attrs map[string]Object) {
+	m.m[name] = &BuiltinModule{Attrs: attrs}
+}
+
+// AddSourceModule adds a source module.
+func (m *ModuleMap) AddSourceModule(name string, src []byte) {
+	m.m[name] = &SourceModule{Src: src}
+}
+
+// Get returns an import module identified by name.
+// It returns if the name is not found.
+func (m *ModuleMap) Get(name string) Importable {
+	return m.m[name]
+}
+
+// GetBuiltinModule returns a builtin module identified by name.
+// It returns if the name is not found or the module is not a builtin module.
+func (m *ModuleMap) GetBuiltinModule(name string) *BuiltinModule {
+	mod, _ := m.m[name].(*BuiltinModule)
+	return mod
+}
+
+// GetSourceModule returns a source module identified by name.
+// It returns if the name is not found or the module is not a source module.
+func (m *ModuleMap) GetSourceModule(name string) *SourceModule {
+	mod, _ := m.m[name].(*SourceModule)
+	return mod
+}
+
+// Copy creates a copy of the module map.
+func (m *ModuleMap) Copy() *ModuleMap {
+	c := &ModuleMap{
+		m: make(map[string]Importable),
+	}
+	for name, mod := range m.m {
+		c.m[name] = mod
+	}
+	return c
+}
+
+// Len returns the number of named modules.
+func (m *ModuleMap) Len() int {
+	return len(m.m)
+}

--- a/objects/source_module.go
+++ b/objects/source_module.go
@@ -6,6 +6,6 @@ type SourceModule struct {
 }
 
 // Import returns a module source code.
-func (m *SourceModule) Import(_ string) (interface{}, error) {
+func (m *SourceModule) Import() (interface{}, error) {
 	return m.Src, nil
 }

--- a/objects/source_module.go
+++ b/objects/source_module.go
@@ -6,6 +6,6 @@ type SourceModule struct {
 }
 
 // Import returns a module source code.
-func (m *SourceModule) Import() (interface{}, error) {
+func (m *SourceModule) Import(_ string) (interface{}, error) {
 	return m.Src, nil
 }

--- a/objects/user_function.go
+++ b/objects/user_function.go
@@ -6,8 +6,9 @@ import (
 
 // UserFunction represents a user function.
 type UserFunction struct {
-	Name  string
-	Value CallableFunc
+	Name       string
+	Value      CallableFunc
+	EncodingID string
 }
 
 // TypeName returns the name of the type.

--- a/runtime/vm_assignment_test.go
+++ b/runtime/vm_assignment_test.go
@@ -206,8 +206,8 @@ out = func() {
 `, nil, 136)
 
 	// assigning different type value
-	expect(t, `a := 1; a = "foo"; out = a`, nil, "foo")                                                 // global
-	expect(t, `func() { a := 1; a = "foo"; out = a }()`, nil, "foo")                                    // local
+	expect(t, `a := 1; a = "foo"; out = a`, nil, "foo")              // global
+	expect(t, `func() { a := 1; a = "foo"; out = a }()`, nil, "foo") // local
 	expect(t, `
 out = func() { 
 	a := 5

--- a/script/script.go
+++ b/script/script.go
@@ -14,7 +14,7 @@ import (
 // Script can simplify compilation and execution of embedded scripts.
 type Script struct {
 	variables        map[string]*Variable
-	importModules    map[string]objects.Importable
+	modules          *objects.ModuleMap
 	input            []byte
 	maxAllocs        int64
 	maxConstObjects  int
@@ -59,8 +59,8 @@ func (s *Script) Remove(name string) bool {
 }
 
 // SetImports sets import modules.
-func (s *Script) SetImports(modules map[string]objects.Importable) {
-	s.importModules = modules
+func (s *Script) SetImports(modules *objects.ModuleMap) {
+	s.modules = modules
 }
 
 // SetMaxAllocs sets the maximum number of objects allocations during the run time.
@@ -96,7 +96,7 @@ func (s *Script) Compile() (*Compiled, error) {
 		return nil, err
 	}
 
-	c := compiler.NewCompiler(srcFile, symbolTable, nil, s.importModules, nil)
+	c := compiler.NewCompiler(srcFile, symbolTable, nil, s.modules, nil)
 	c.EnableFileImport(s.enableFileImport)
 	if err := c.Compile(file); err != nil {
 		return nil, err

--- a/script/script_concurrency_test.go
+++ b/script/script_concurrency_test.go
@@ -45,14 +45,12 @@ for i:=1; i<=d; i++ {
 
 e := mod1.double(s)
 `)
-	mod1 := &objects.BuiltinModule{
-		Attrs: map[string]objects.Object{
-			"double": &objects.UserFunction{
-				Value: func(args ...objects.Object) (ret objects.Object, err error) {
-					arg0, _ := objects.ToInt64(args[0])
-					ret = &objects.Int{Value: arg0 * 2}
-					return
-				},
+	mod1 := map[string]objects.Object{
+		"double": &objects.UserFunction{
+			Value: func(args ...objects.Object) (ret objects.Object, err error) {
+				arg0, _ := objects.ToInt64(args[0])
+				ret = &objects.Int{Value: arg0 * 2}
+				return
 			},
 		},
 	}
@@ -61,9 +59,9 @@ e := mod1.double(s)
 	_ = scr.Add("a", 0)
 	_ = scr.Add("b", 0)
 	_ = scr.Add("c", 0)
-	scr.SetImports(map[string]objects.Importable{
-		"mod1": mod1,
-	})
+	mods := objects.NewModuleMap()
+	mods.AddBuiltinModule("mod1", mod1)
+	scr.SetImports(mods)
 	compiled, err := scr.Compile()
 	assert.NoError(t, err)
 

--- a/script/script_module_test.go
+++ b/script/script_module_test.go
@@ -12,38 +12,44 @@ import (
 func TestScriptSourceModule(t *testing.T) {
 	// script1 imports "mod1"
 	scr := script.New([]byte(`out := import("mod")`))
-	scr.SetImports(map[string]objects.Importable{
-		"mod": &objects.SourceModule{Src: []byte(`export 5`)},
-	})
+	mods := objects.NewModuleMap()
+	mods.AddSourceModule("mod", []byte(`export 5`))
+	scr.SetImports(mods)
 	c, err := scr.Run()
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, int64(5), c.Get("out").Value())
 
 	// executing module function
 	scr = script.New([]byte(`fn := import("mod"); out := fn()`))
-	scr.SetImports(map[string]objects.Importable{
-		"mod": &objects.SourceModule{Src: []byte(`a := 3; export func() { return a + 5 }`)},
-	})
+	mods = objects.NewModuleMap()
+	mods.AddSourceModule("mod", []byte(`a := 3; export func() { return a + 5 }`))
+	scr.SetImports(mods)
 	c, err = scr.Run()
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, int64(8), c.Get("out").Value())
 
 	scr = script.New([]byte(`out := import("mod")`))
-	scr.SetImports(map[string]objects.Importable{
-		"text": &objects.BuiltinModule{
-			Attrs: map[string]objects.Object{
-				"title": &objects.UserFunction{Name: "title", Value: func(args ...objects.Object) (ret objects.Object, err error) {
-					s, _ := objects.ToString(args[0])
-					return &objects.String{Value: strings.Title(s)}, nil
-				}},
-			},
-		},
-		"mod": &objects.SourceModule{Src: []byte(`text := import("text"); export text.title("foo")`)},
+	mods = objects.NewModuleMap()
+	mods.AddSourceModule("mod", []byte(`text := import("text"); export text.title("foo")`))
+	mods.AddBuiltinModule("text", map[string]objects.Object{
+		"title": &objects.UserFunction{Name: "title", Value: func(args ...objects.Object) (ret objects.Object, err error) {
+			s, _ := objects.ToString(args[0])
+			return &objects.String{Value: strings.Title(s)}, nil
+		}},
 	})
+	scr.SetImports(mods)
 	c, err = scr.Run()
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, "Foo", c.Get("out").Value())
 	scr.SetImports(nil)
 	_, err = scr.Run()
-	assert.Error(t, err)
-
+	if !assert.Error(t, err) {
+		return
+	}
 }

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -53,7 +53,7 @@ func TestScript_Run(t *testing.T) {
 
 func TestScript_BuiltinModules(t *testing.T) {
 	s := script.New([]byte(`math := import("math"); a := math.abs(-19.84)`))
-	s.SetImports(stdlib.GetModules("math"))
+	s.SetImports(stdlib.GetModuleMap("math"))
 	c, err := s.Run()
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
@@ -64,7 +64,7 @@ func TestScript_BuiltinModules(t *testing.T) {
 	assert.NotNil(t, c)
 	compiledGet(t, c, "a", 19.84)
 
-	s.SetImports(stdlib.GetModules("os"))
+	s.SetImports(stdlib.GetModuleMap("os"))
 	_, err = s.Run()
 	assert.Error(t, err)
 
@@ -80,7 +80,7 @@ a := enum.all([1,2,3], func(_, v) {
 	return v > 0 
 })
 `))
-	s.SetImports(stdlib.GetModules("enum"))
+	s.SetImports(stdlib.GetModuleMap("enum"))
 	c, err := s.Run()
 	assert.NoError(t, err)
 	assert.NotNil(t, c)

--- a/script/script_test.go
+++ b/script/script_test.go
@@ -53,7 +53,7 @@ func TestScript_Run(t *testing.T) {
 
 func TestScript_BuiltinModules(t *testing.T) {
 	s := script.New([]byte(`math := import("math"); a := math.abs(-19.84)`))
-	s.SetImports(map[string]objects.Importable{"math": stdlib.BuiltinModules["math"]})
+	s.SetImports(stdlib.GetModules("math"))
 	c, err := s.Run()
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
@@ -64,7 +64,7 @@ func TestScript_BuiltinModules(t *testing.T) {
 	assert.NotNil(t, c)
 	compiledGet(t, c, "a", 19.84)
 
-	s.SetImports(map[string]objects.Importable{"os": &objects.BuiltinModule{Attrs: map[string]objects.Object{}}})
+	s.SetImports(stdlib.GetModules("os"))
 	_, err = s.Run()
 	assert.Error(t, err)
 

--- a/stdlib/builtin_modules.go
+++ b/stdlib/builtin_modules.go
@@ -4,11 +4,11 @@ import "github.com/d5/tengo/objects"
 
 // BuiltinModules are builtin type standard library modules.
 var BuiltinModules = map[string]*objects.BuiltinModule{
-	"math":  {Attrs: mathModule},
-	"os":    {Attrs: osModule},
-	"text":  {Attrs: textModule},
-	"times": {Attrs: timesModule},
-	"rand":  {Attrs: randModule},
-	"fmt":   {Attrs: fmtModule},
-	"json":  {Attrs: jsonModule},
+	"math":  {Name: "math", Attrs: mathModule},
+	"os":    {Name: "os", Attrs: osModule},
+	"text":  {Name: "text", Attrs: textModule},
+	"times": {Name: "times", Attrs: timesModule},
+	"rand":  {Name: "rand", Attrs: randModule},
+	"fmt":   {Name: "fmt", Attrs: fmtModule},
+	"json":  {Name: "json", Attrs: jsonModule},
 }

--- a/stdlib/builtin_modules.go
+++ b/stdlib/builtin_modules.go
@@ -3,12 +3,12 @@ package stdlib
 import "github.com/d5/tengo/objects"
 
 // BuiltinModules are builtin type standard library modules.
-var BuiltinModules = map[string]*objects.BuiltinModule{
-	"math":  {Name: "math", Attrs: mathModule},
-	"os":    {Name: "os", Attrs: osModule},
-	"text":  {Name: "text", Attrs: textModule},
-	"times": {Name: "times", Attrs: timesModule},
-	"rand":  {Name: "rand", Attrs: randModule},
-	"fmt":   {Name: "fmt", Attrs: fmtModule},
-	"json":  {Name: "json", Attrs: jsonModule},
+var BuiltinModules = map[string]map[string]objects.Object{
+	"math":  mathModule,
+	"os":    osModule,
+	"text":  textModule,
+	"times": timesModule,
+	"rand":  randModule,
+	"fmt":   fmtModule,
+	"json":  jsonModule,
 }

--- a/stdlib/gensrcmods.go
+++ b/stdlib/gensrcmods.go
@@ -38,12 +38,10 @@ func main() {
 
 package stdlib
 
-import "github.com/d5/tengo/objects"
-
 // SourceModules are source type standard library modules.
-var SourceModules = map[string]*objects.SourceModule{` + "\n")
+var SourceModules = map[string]string{` + "\n")
 	for modName, modSrc := range modules {
-		out.WriteString("\t\"" + modName + "\": {Src: []byte(`" + modSrc + "`)},\n")
+		out.WriteString("\t\"" + modName + "\": `" + modSrc + "`,\n")
 	}
 	out.WriteString("}\n")
 

--- a/stdlib/source_modules.go
+++ b/stdlib/source_modules.go
@@ -2,11 +2,9 @@
 
 package stdlib
 
-import "github.com/d5/tengo/objects"
-
 // SourceModules are source type standard library modules.
-var SourceModules = map[string]*objects.SourceModule{
-	"enum": {Src: []byte(`export {
+var SourceModules = map[string]string{
+	"enum": `export {
   // all returns true if the given function fn evaluates to a truthy value on
   // all of the items in the enumerable.
   all: func(enumerable, fn) {
@@ -46,5 +44,5 @@ var SourceModules = map[string]*objects.SourceModule{
     return res
   }
 }
-`)},
+`,
 }

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -18,14 +18,15 @@ func AllModuleNames() []string {
 
 // GetModules returns the modules for the given names.
 // Duplicate names and invalid names are ignore.
-func GetModules(names ...string) map[string]objects.Importable {
-	modules := make(map[string]objects.Importable)
+func GetModules(names ...string) *objects.ModuleMap {
+	modules := objects.NewModuleMap()
+
 	for _, name := range names {
 		if mod := BuiltinModules[name]; mod != nil {
-			modules[name] = mod
+			modules.AddBuiltinModule(name, mod)
 		}
-		if mod := SourceModules[name]; mod != nil {
-			modules[name] = mod
+		if mod := SourceModules[name]; mod != "" {
+			modules.AddSourceModule(name, []byte(mod))
 		}
 	}
 

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -16,9 +16,9 @@ func AllModuleNames() []string {
 	return names
 }
 
-// GetModules returns the modules for the given names.
-// Duplicate names and invalid names are ignore.
-func GetModules(names ...string) *objects.ModuleMap {
+// GetModuleMap returns the module map that includes all modules
+// for the given module names.
+func GetModuleMap(names ...string) *objects.ModuleMap {
 	modules := objects.NewModuleMap()
 
 	for _, name := range names {

--- a/stdlib/stdlib_test.go
+++ b/stdlib/stdlib_test.go
@@ -74,23 +74,23 @@ if !is_error(cmd) {
 }
 
 func TestGetModules(t *testing.T) {
-	mods := stdlib.GetModules()
+	mods := stdlib.GetModuleMap()
 	assert.Equal(t, 0, mods.Len())
 
-	mods = stdlib.GetModules("os")
+	mods = stdlib.GetModuleMap("os")
 	assert.Equal(t, 1, mods.Len())
 	assert.NotNil(t, mods.Get("os"))
 
-	mods = stdlib.GetModules("os", "rand")
+	mods = stdlib.GetModuleMap("os", "rand")
 	assert.Equal(t, 2, mods.Len())
 	assert.NotNil(t, mods.Get("os"))
 	assert.NotNil(t, mods.Get("rand"))
 
-	mods = stdlib.GetModules("text", "text")
+	mods = stdlib.GetModuleMap("text", "text")
 	assert.Equal(t, 1, mods.Len())
 	assert.NotNil(t, mods.Get("text"))
 
-	mods = stdlib.GetModules("nonexisting", "text")
+	mods = stdlib.GetModuleMap("nonexisting", "text")
 	assert.Equal(t, 1, mods.Len())
 	assert.NotNil(t, mods.Get("text"))
 }
@@ -156,7 +156,7 @@ func (c callres) expectError() bool {
 }
 
 func module(t *testing.T, moduleName string) callres {
-	mod := stdlib.GetModules(moduleName).GetBuiltinModule(moduleName)
+	mod := stdlib.GetModuleMap(moduleName).GetBuiltinModule(moduleName)
 	if mod == nil {
 		return callres{t: t, e: fmt.Errorf("module not found: %s", moduleName)}
 	}
@@ -231,7 +231,7 @@ func object(v interface{}) objects.Object {
 
 func expect(t *testing.T, input string, expected interface{}) {
 	s := script.New([]byte(input))
-	s.SetImports(stdlib.GetModules(stdlib.AllModuleNames()...))
+	s.SetImports(stdlib.GetModuleMap(stdlib.AllModuleNames()...))
 	c, err := s.Run()
 	assert.NoError(t, err)
 	assert.NotNil(t, c)

--- a/stdlib/stdlib_test.go
+++ b/stdlib/stdlib_test.go
@@ -75,24 +75,24 @@ if !is_error(cmd) {
 
 func TestGetModules(t *testing.T) {
 	mods := stdlib.GetModules()
-	assert.Equal(t, 0, len(mods))
+	assert.Equal(t, 0, mods.Len())
 
 	mods = stdlib.GetModules("os")
-	assert.Equal(t, 1, len(mods))
-	assert.NotNil(t, mods["os"])
+	assert.Equal(t, 1, mods.Len())
+	assert.NotNil(t, mods.Get("os"))
 
 	mods = stdlib.GetModules("os", "rand")
-	assert.Equal(t, 2, len(mods))
-	assert.NotNil(t, mods["os"])
-	assert.NotNil(t, mods["rand"])
+	assert.Equal(t, 2, mods.Len())
+	assert.NotNil(t, mods.Get("os"))
+	assert.NotNil(t, mods.Get("rand"))
 
 	mods = stdlib.GetModules("text", "text")
-	assert.Equal(t, 1, len(mods))
-	assert.NotNil(t, mods["text"])
+	assert.Equal(t, 1, mods.Len())
+	assert.NotNil(t, mods.Get("text"))
 
 	mods = stdlib.GetModules("nonexisting", "text")
-	assert.Equal(t, 1, len(mods))
-	assert.NotNil(t, mods["text"])
+	assert.Equal(t, 1, mods.Len())
+	assert.NotNil(t, mods.Get("text"))
 }
 
 type callres struct {
@@ -156,8 +156,8 @@ func (c callres) expectError() bool {
 }
 
 func module(t *testing.T, moduleName string) callres {
-	mod, ok := stdlib.BuiltinModules[moduleName]
-	if !ok {
+	mod := stdlib.GetModules(moduleName).GetBuiltinModule(moduleName)
+	if mod == nil {
 		return callres{t: t, e: fmt.Errorf("module not found: %s", moduleName)}
 	}
 


### PR DESCRIPTION
This PR is to fix an issue where decoded bytecode from binary has `nil` user functions. Bytecode decoder detects builtin modules (immutable maps with special field `__module_name__`) and replace them with known runtime builtin modules on the fly.