### PR TITLE
Consistent Map set and get

### DIFF
--- a/objects/map.go
+++ b/objects/map.go
@@ -76,13 +76,13 @@ func (o *Map) Equals(x Object) bool {
 
 // IndexGet returns the value for the given key.
 func (o *Map) IndexGet(index Object) (res Object, err error) {
-	strIdx, ok := index.(*String)
+	strIdx, ok := ToString(index)
 	if !ok {
 		err = ErrInvalidIndexType
 		return
 	}
 
-	val, ok := o.Value[strIdx.Value]
+	val, ok := o.Value[strIdx]
 	if !ok {
 		val = UndefinedValue
 	}

--- a/objects/map_test.go
+++ b/objects/map_test.go
@@ -1,0 +1,21 @@
+package objects_test
+
+import (
+	"testing"
+
+	"github.com/d5/tengo/assert"
+	"github.com/d5/tengo/objects"
+)
+
+func TestMap_Index(t *testing.T) {
+	m := &objects.Map{Value: make(map[string]objects.Object)}
+	k := &objects.Int{Value: 1}
+	v := &objects.String{Value: "abcdef"}
+	err := m.IndexSet(k, v)
+
+	assert.NoError(t, err)
+
+	res, err := m.IndexGet(k)
+	assert.NoError(t, err)
+	assert.Equal(t, v, res)
+}


### PR DESCRIPTION
Fixed the case where the a map element can be set with non-string key but can't be accessed with one.
