### PR TITLE
Substring function

### DIFF
--- a/stdlib/text.go
+++ b/stdlib/text.go
@@ -32,7 +32,7 @@ var textModule = map[string]objects.Object{
 	"last_index_any": &objects.UserFunction{Name: "last_index_any", Value: FuncASSRI(strings.LastIndexAny)}, // last_index_any(s, chars) => int
 	"repeat":         &objects.UserFunction{Name: "repeat", Value: textRepeat},                              // repeat(s, count) => string
 	"replace":        &objects.UserFunction{Name: "replace", Value: textReplace},                            // replace(s, old, new, n) => string
-	"substring":      &objects.UserFunction{Name: "substring", Value: textSubstring},                        // substring(s, start, end) => string
+	"substr":         &objects.UserFunction{Name: "substr", Value: textSubstring},                           // substring(s, lower, upper) => string
 	"split":          &objects.UserFunction{Name: "split", Value: FuncASSRSs(strings.Split)},                // split(s, sep) => [string]
 	"split_after":    &objects.UserFunction{Name: "split_after", Value: FuncASSRSs(strings.SplitAfter)},     // split_after(s, sep) => [string]
 	"split_after_n":  &objects.UserFunction{Name: "split_after_n", Value: FuncASSIRSs(strings.SplitAfterN)}, // split_after_n(s, sep, n) => [string]
@@ -378,7 +378,8 @@ func textReplace(args ...objects.Object) (ret objects.Object, err error) {
 }
 
 func textSubstring(args ...objects.Object) (ret objects.Object, err error) {
-	if len(args) != 3 {
+	argslen := len(args)
+	if argslen != 2 && argslen != 3 {
 		err = objects.ErrWrongNumArguments
 		return
 	}
@@ -403,14 +404,18 @@ func textSubstring(args ...objects.Object) (ret objects.Object, err error) {
 		return
 	}
 
-	i3, ok := objects.ToInt(args[2])
-	if !ok {
-		err = objects.ErrInvalidArgumentType{
-			Name:     "third",
-			Expected: "int(compatible)",
-			Found:    args[2].TypeName(),
+	strlen := len(s1)
+	i3 := strlen
+	if argslen == 3 {
+		i3, ok = objects.ToInt(args[2])
+		if !ok {
+			err = objects.ErrInvalidArgumentType{
+				Name:     "third",
+				Expected: "int(compatible)",
+				Found:    args[2].TypeName(),
+			}
+			return
 		}
-		return
 	}
 
 	if i2 > i3 {
@@ -418,7 +423,6 @@ func textSubstring(args ...objects.Object) (ret objects.Object, err error) {
 		return
 	}
 
-	strlen := len(s1)
 	if i2 < 0 {
 		i2 = 0
 	} else if i2 > strlen {

--- a/stdlib/text.go
+++ b/stdlib/text.go
@@ -32,6 +32,7 @@ var textModule = map[string]objects.Object{
 	"last_index_any": &objects.UserFunction{Name: "last_index_any", Value: FuncASSRI(strings.LastIndexAny)}, // last_index_any(s, chars) => int
 	"repeat":         &objects.UserFunction{Name: "repeat", Value: textRepeat},                              // repeat(s, count) => string
 	"replace":        &objects.UserFunction{Name: "replace", Value: textReplace},                            // replace(s, old, new, n) => string
+	"substring":      &objects.UserFunction{Name: "substring", Value: textSubstring},                        // substring(s, start, end) => string
 	"split":          &objects.UserFunction{Name: "split", Value: FuncASSRSs(strings.Split)},                // split(s, sep) => [string]
 	"split_after":    &objects.UserFunction{Name: "split_after", Value: FuncASSRSs(strings.SplitAfter)},     // split_after(s, sep) => [string]
 	"split_after_n":  &objects.UserFunction{Name: "split_after_n", Value: FuncASSIRSs(strings.SplitAfterN)}, // split_after_n(s, sep, n) => [string]
@@ -372,6 +373,65 @@ func textReplace(args ...objects.Object) (ret objects.Object, err error) {
 	}
 
 	ret = &objects.String{Value: s}
+
+	return
+}
+
+func textSubstring(args ...objects.Object) (ret objects.Object, err error) {
+	if len(args) != 3 {
+		err = objects.ErrWrongNumArguments
+		return
+	}
+
+	s1, ok := objects.ToString(args[0])
+	if !ok {
+		err = objects.ErrInvalidArgumentType{
+			Name:     "first",
+			Expected: "string(compatible)",
+			Found:    args[0].TypeName(),
+		}
+		return
+	}
+
+	i2, ok := objects.ToInt(args[1])
+	if !ok {
+		err = objects.ErrInvalidArgumentType{
+			Name:     "second",
+			Expected: "int(compatible)",
+			Found:    args[1].TypeName(),
+		}
+		return
+	}
+
+	i3, ok := objects.ToInt(args[2])
+	if !ok {
+		err = objects.ErrInvalidArgumentType{
+			Name:     "third",
+			Expected: "int(compatible)",
+			Found:    args[2].TypeName(),
+		}
+		return
+	}
+
+	if i2 > i3 {
+		err = objects.ErrInvalidIndexType
+		return
+	}
+
+	strlen := len(s1)
+	if i2 < 0 {
+		i2 = 0
+	} else if i2 > strlen {
+		i2 = strlen
+	}
+
+	if i3 < 0 {
+		i3 = 0
+	} else if i3 > strlen {
+		i3 = strlen
+	}
+
+	ret = &objects.String{Value: s1[i2:i3]}
 
 	return
 }

--- a/stdlib/text_test.go
+++ b/stdlib/text_test.go
@@ -246,18 +246,20 @@ func TestTextRepeat(t *testing.T) {
 }
 
 func TestSubstr(t *testing.T) {
-	module(t, "text").call("substring", "", 0, 0).expect("")
-	module(t, "text").call("substring", "abcdef", 0, 3).expect("abc")
-	module(t, "text").call("substring", "abcdef", 0, 6).expect("abcdef")
-	module(t, "text").call("substring", "abcdef", 0, 10).expect("abcdef")
-	module(t, "text").call("substring", "abcdef", -10, 10).expect("abcdef")
+	module(t, "text").call("substr", "", 0, 0).expect("")
+	module(t, "text").call("substr", "abcdef", 0, 3).expect("abc")
+	module(t, "text").call("substr", "abcdef", 0, 6).expect("abcdef")
+	module(t, "text").call("substr", "abcdef", 0, 10).expect("abcdef")
+	module(t, "text").call("substr", "abcdef", -10, 10).expect("abcdef")
+	module(t, "text").call("substr", "abcdef", 0).expect("abcdef")
+	module(t, "text").call("substr", "abcdef", 3).expect("def")
 
-	module(t, "text").call("substring", "", 10, 0).expectError()
-	module(t, "text").call("substring", "", "10", 0).expectError()
-	module(t, "text").call("substring", "", 10, "0").expectError()
-	module(t, "text").call("substring", "", "10", "0").expectError()
+	module(t, "text").call("substr", "", 10, 0).expectError()
+	module(t, "text").call("substr", "", "10", 0).expectError()
+	module(t, "text").call("substr", "", 10, "0").expectError()
+	module(t, "text").call("substr", "", "10", "0").expectError()
 
-	module(t, "text").call("substring", 0, 0, 1).expect("0")
-	module(t, "text").call("substring", 123, 0, 1).expect("1")
-	module(t, "text").call("substring", 123.456, 4, 7).expect("456")
+	module(t, "text").call("substr", 0, 0, 1).expect("0")
+	module(t, "text").call("substr", 123, 0, 1).expect("1")
+	module(t, "text").call("substr", 123.456, 4, 7).expect("456")
 }

--- a/stdlib/text_test.go
+++ b/stdlib/text_test.go
@@ -244,3 +244,20 @@ func TestTextRepeat(t *testing.T) {
 	module(t, "text").call("repeat", "1", "12").expect("111111111111")
 	module(t, "text").call("repeat", "1", "13").expectError()
 }
+
+func TestSubstr(t *testing.T) {
+	module(t, "text").call("substring", "", 0, 0).expect("")
+	module(t, "text").call("substring", "abcdef", 0, 3).expect("abc")
+	module(t, "text").call("substring", "abcdef", 0, 6).expect("abcdef")
+	module(t, "text").call("substring", "abcdef", 0, 10).expect("abcdef")
+	module(t, "text").call("substring", "abcdef", -10, 10).expect("abcdef")
+
+	module(t, "text").call("substring", "", 10, 0).expectError()
+	module(t, "text").call("substring", "", "10", 0).expectError()
+	module(t, "text").call("substring", "", 10, "0").expectError()
+	module(t, "text").call("substring", "", "10", "0").expectError()
+
+	module(t, "text").call("substring", 0, 0, 1).expect("0")
+	module(t, "text").call("substring", 123, 0, 1).expect("1")
+	module(t, "text").call("substring", 123.456, 4, 7).expect("456")
+}


### PR DESCRIPTION
String slicing with range doesn't work for variables that are expected to be string but turn out to not be strings (especially when retrieved from json). Substring function deals with such scenarios better than string conversion followed by slicing (works similar to other functions in the text library by first converting the object to string). 