### PR TITLE
Fix %v formatting

### DIFF
--- a/stdlib/fmt.go
+++ b/stdlib/fmt.go
@@ -46,7 +46,12 @@ func fmtPrintf(args ...objects.Object) (ret objects.Object, err error) {
 
 	formatArgs := make([]interface{}, numArgs-1, numArgs-1)
 	for idx, arg := range args[1:] {
-		formatArgs[idx] = objects.ToInterface(arg)
+		switch arg := arg.(type) {
+		case *objects.Int, *objects.Float, *objects.Bool, *objects.Char, *objects.Time, *objects.String:
+			formatArgs[idx] = objects.ToInterface(arg)
+		default:
+			formatArgs[idx] = arg
+		}
 	}
 
 	fmt.Printf(format.Value, formatArgs...)
@@ -86,7 +91,12 @@ func fmtSprintf(args ...objects.Object) (ret objects.Object, err error) {
 
 	formatArgs := make([]interface{}, numArgs-1, numArgs-1)
 	for idx, arg := range args[1:] {
-		formatArgs[idx] = objects.ToInterface(arg)
+		switch arg := arg.(type) {
+		case *objects.Int, *objects.Float, *objects.Bool, *objects.Char, *objects.Time, *objects.String:
+			formatArgs[idx] = objects.ToInterface(arg)
+		default:
+			formatArgs[idx] = arg
+		}
 	}
 
 	s := fmt.Sprintf(format.Value, formatArgs...)

--- a/stdlib/fmt.go
+++ b/stdlib/fmt.go
@@ -47,7 +47,7 @@ func fmtPrintf(args ...objects.Object) (ret objects.Object, err error) {
 	formatArgs := make([]interface{}, numArgs-1, numArgs-1)
 	for idx, arg := range args[1:] {
 		switch arg := arg.(type) {
-		case *objects.Int, *objects.Float, *objects.Bool, *objects.Char, *objects.Time, *objects.String:
+		case *objects.Int, *objects.Float, *objects.Bool, *objects.Char, *objects.String, *objects.Bytes:
 			formatArgs[idx] = objects.ToInterface(arg)
 		default:
 			formatArgs[idx] = arg
@@ -92,7 +92,7 @@ func fmtSprintf(args ...objects.Object) (ret objects.Object, err error) {
 	formatArgs := make([]interface{}, numArgs-1, numArgs-1)
 	for idx, arg := range args[1:] {
 		switch arg := arg.(type) {
-		case *objects.Int, *objects.Float, *objects.Bool, *objects.Char, *objects.Time, *objects.String:
+		case *objects.Int, *objects.Float, *objects.Bool, *objects.Char, *objects.String, *objects.Bytes:
 			formatArgs[idx] = objects.ToInterface(arg)
 		default:
 			formatArgs[idx] = arg

--- a/stdlib/fmt_test.go
+++ b/stdlib/fmt_test.go
@@ -6,7 +6,8 @@ func TestFmtSprintf(t *testing.T) {
 	module(t, `fmt`).call("sprintf", "").expect("")
 	module(t, `fmt`).call("sprintf", "foo").expect("foo")
 	module(t, `fmt`).call("sprintf", `foo %d %v %s`, 1, 2, "bar").expect("foo 1 2 bar")
-	module(t, `fmt`).call("sprintf", "foo %v", `[1, "bar", true]`).expect(`foo [1, "bar", true]`)
-	module(t, `fmt`).call("sprintf", "foo %v %d", `[1, "bar", true]`, 19).expect(`foo [1, "bar", true] 19`)
-	module(t, `fmt`).call("sprintf", "foo %v", `{a: {b: {c: [1, 2, 3]}}}`).expect(`foo {a: {b: {c: [1, 2, 3]}}}`)
+	module(t, `fmt`).call("sprintf", "foo %v", ARR{1, "bar", true}).expect(`foo [1, "bar", true]`)
+	module(t, `fmt`).call("sprintf", "foo %v %d", ARR{1, "bar", true}, 19).expect(`foo [1, "bar", true] 19`)
+	module(t, `fmt`).call("sprintf", "foo %v", MAP{"a": IMAP{"b": IMAP{"c": ARR{1, 2, 3}}}}).expect(`foo {a: {b: {c: [1, 2, 3]}}}`)
+	module(t, `fmt`).call("sprintf", "%v", IARR{1, IARR{2, IARR{3, 4}}}).expect(`[1, [2, [3, 4]]]`)
 }

--- a/stdlib/fmt_test.go
+++ b/stdlib/fmt_test.go
@@ -8,4 +8,5 @@ func TestFmtSprintf(t *testing.T) {
 	module(t, `fmt`).call("sprintf", `foo %d %v %s`, 1, 2, "bar").expect("foo 1 2 bar")
 	module(t, `fmt`).call("sprintf", "foo %v", `[1, "bar", true]`).expect(`foo [1, "bar", true]`)
 	module(t, `fmt`).call("sprintf", "foo %v %d", `[1, "bar", true]`, 19).expect(`foo [1, "bar", true] 19`)
+	module(t, `fmt`).call("sprintf", "foo %v", `{a: {b: {c: [1, 2, 3]}}}`).expect(`foo {a: {b: {c: [1, 2, 3]}}}`)
 }


### PR DESCRIPTION
fixes #143 

All Objects implement String(), so %v would work automatically if they're not converted to interface.