### PR TITLE
Added format (alias for fmt.sprintf) to builtins.

### DIFF
--- a/objects/builtin_format.go
+++ b/objects/builtin_format.go
@@ -1,0 +1,44 @@
+package objects
+
+import (
+	"fmt"
+
+	"github.com/d5/tengo"
+)
+
+func builtinFormat(args ...Object) (Object, error) {
+	numArgs := len(args)
+	if numArgs == 0 {
+		return nil, ErrWrongNumArguments
+	}
+
+	format, ok := args[0].(*String)
+	if !ok {
+		return nil, ErrInvalidArgumentType{
+			Name:     "format",
+			Expected: "string",
+			Found:    args[0].TypeName(),
+		}
+	}
+	if numArgs == 1 {
+		return format, nil // okay to return 'format' directly as String is immutable
+	}
+
+	formatArgs := make([]interface{}, numArgs-1, numArgs-1)
+	for idx, arg := range args[1:] {
+		switch arg := arg.(type) {
+		case *Int, *Float, *Bool, *Char, *String, *Bytes:
+			formatArgs[idx] = ToInterface(arg)
+		default:
+			formatArgs[idx] = arg
+		}
+	}
+
+	s := fmt.Sprintf(format.Value, formatArgs...)
+
+	if len(s) > tengo.MaxStringLen {
+		return nil, ErrStringLimit
+	}
+
+	return &String{Value: s}, nil
+}

--- a/objects/builtin_format.go
+++ b/objects/builtin_format.go
@@ -24,7 +24,7 @@ func builtinFormat(args ...Object) (Object, error) {
 		return format, nil // okay to return 'format' directly as String is immutable
 	}
 
-	formatArgs := make([]interface{}, numArgs-1, numArgs-1)
+	formatArgs := make([]interface{}, numArgs-1)
 	for idx, arg := range args[1:] {
 		switch arg := arg.(type) {
 		case *Int, *Float, *Bool, *Char, *String, *Bytes:

--- a/objects/builtins.go
+++ b/objects/builtins.go
@@ -111,4 +111,8 @@ var Builtins = []*BuiltinFunction{
 		Name:  "type_name",
 		Value: builtinTypeName,
 	},
+	{
+		Name:  "format",
+		Value: builtinFormat,
+	},
 }


### PR DESCRIPTION
String formatting is a very common application in data transformations, and should be available outside of fmt, both in general and in tengomin. 

This is also a precursor to removing support for `string + non-string`. Right now there is an inconsistency in results of of the `+` operator purely depending on whether the first operand is a `string` or not, which is a confusing scenario and can lead to easily avoidable errors. 

It's best to remove support for `string + non-string` and force the user to either forcibly cast every variable to string and append them or to use the `format()` function.