### PR TITLE
variable-argument functions

### DIFF
--- a/compiler/ast/ident_list.go
+++ b/compiler/ast/ident_list.go
@@ -8,9 +8,10 @@ import (
 
 // IdentList represents a list of identifiers.
 type IdentList struct {
-	LParen source.Pos
-	List   []*Ident
-	RParen source.Pos
+	LParen  source.Pos
+	VarArgs bool
+	List    []*Ident
+	RParen  source.Pos
 }
 
 // Pos returns the position of first character belonging to the node.

--- a/compiler/ast/ident_list.go
+++ b/compiler/ast/ident_list.go
@@ -1,7 +1,6 @@
 package ast
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/d5/tengo/compiler/source"
@@ -51,13 +50,12 @@ func (n *IdentList) NumFields() int {
 }
 
 func (n *IdentList) String() string {
-	if n.VarArgs {
-		return fmt.Sprintf("(...%s)", n.List[0].Name)
-	}
-
 	var list []string
-	for _, e := range n.List {
+	for i, e := range n.List {
 		list = append(list, e.String())
+		if n.VarArgs && i == len(n.List)-1 {
+			list = append(list, "..."+e.String())
+		}
 	}
 
 	return "(" + strings.Join(list, ", ") + ")"

--- a/compiler/ast/ident_list.go
+++ b/compiler/ast/ident_list.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/d5/tengo/compiler/source"
@@ -50,6 +51,10 @@ func (n *IdentList) NumFields() int {
 }
 
 func (n *IdentList) String() string {
+	if n.VarArgs {
+		return fmt.Sprintf("(...%s)", n.List[0].Name)
+	}
+
 	var list []string
 	for _, e := range n.List {
 		list = append(list, e.String())

--- a/compiler/ast/ident_list.go
+++ b/compiler/ast/ident_list.go
@@ -52,9 +52,10 @@ func (n *IdentList) NumFields() int {
 func (n *IdentList) String() string {
 	var list []string
 	for i, e := range n.List {
-		list = append(list, e.String())
 		if n.VarArgs && i == len(n.List)-1 {
 			list = append(list, "..."+e.String())
+		} else {
+			list = append(list, e.String())
 		}
 	}
 

--- a/compiler/ast/ident_list_test.go
+++ b/compiler/ast/ident_list_test.go
@@ -1,0 +1,37 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/d5/tengo/compiler/ast"
+)
+
+func TestIdentListString(t *testing.T) {
+	identListVar := &ast.IdentList{
+		List: []*ast.Ident{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+		},
+		VarArgs: true,
+	}
+
+	expectedVar := "(a, b, ...c)"
+	if str := identListVar.String(); str != expectedVar {
+		t.Fatalf("expected string of %#v to be %s, got %s", identListVar, expectedVar, str)
+	}
+
+	identList := &ast.IdentList{
+		List: []*ast.Ident{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+		},
+		VarArgs: false,
+	}
+
+	expected := "(a, b, c)"
+	if str := identList.String(); str != expected {
+		t.Fatalf("expected string of %#v to be %s, got %s", identList, expected, str)
+	}
+}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -477,6 +477,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 			Instructions:  instructions,
 			NumLocals:     numLocals,
 			NumParameters: len(node.Type.Params.List),
+			VarArgs:       node.Type.Params.VarArgs,
 			SourceMap:     sourceMap,
 		}
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -670,6 +670,23 @@ func TestCompiler_Compile(t *testing.T) {
 					compiler.MakeInstruction(compiler.OpReturn, 1)),
 				intObject(24))))
 
+	expect(t, `varTest := func(...a) { return a }; varTest(1,2,3);`,
+		bytecode(
+			concat(
+				compiler.MakeInstruction(compiler.OpConstant, 0),
+				compiler.MakeInstruction(compiler.OpSetGlobal, 0),
+				compiler.MakeInstruction(compiler.OpGetGlobal, 0),
+				compiler.MakeInstruction(compiler.OpConstant, 1),
+				compiler.MakeInstruction(compiler.OpConstant, 2),
+				compiler.MakeInstruction(compiler.OpConstant, 3),
+				compiler.MakeInstruction(compiler.OpCall, 3),
+				compiler.MakeInstruction(compiler.OpPop)),
+			objectsArray(
+				compiledFunction(1, 1,
+					compiler.MakeInstruction(compiler.OpGetLocal, 0),
+					compiler.MakeInstruction(compiler.OpReturn, 1)),
+				intObject(1), intObject(2), intObject(3))))
+
 	expect(t, `f1 := func(a, b, c) { a; b; return c; }; f1(24, 25, 26);`,
 		bytecode(
 			concat(

--- a/compiler/opcodes.go
+++ b/compiler/opcodes.go
@@ -46,6 +46,7 @@ const (
 	OpIteratorKey                 // Iterator key
 	OpIteratorValue               // Iterator value
 	OpBinaryOp                    // Binary Operation
+	OpVarArgs                     // Initialize VarArgs parameter in function body
 )
 
 // OpcodeNames is opcode names.
@@ -91,6 +92,7 @@ var OpcodeNames = [...]string{
 	OpIteratorKey:   "ITKEY",
 	OpIteratorValue: "ITVAL",
 	OpBinaryOp:      "BINARYOP",
+	OpVarArgs:       "VARARGS",
 }
 
 // OpcodeOperands is the number of operands.
@@ -136,6 +138,7 @@ var OpcodeOperands = [...][]int{
 	OpIteratorKey:   {},
 	OpIteratorValue: {},
 	OpBinaryOp:      {1},
+	OpVarArgs:       {1},
 }
 
 // ReadOperands reads operands from the bytecode.

--- a/compiler/opcodes.go
+++ b/compiler/opcodes.go
@@ -46,7 +46,6 @@ const (
 	OpIteratorKey                 // Iterator key
 	OpIteratorValue               // Iterator value
 	OpBinaryOp                    // Binary Operation
-	OpVarArgs                     // Initialize VarArgs parameter in function body
 )
 
 // OpcodeNames is opcode names.
@@ -92,7 +91,6 @@ var OpcodeNames = [...]string{
 	OpIteratorKey:   "ITKEY",
 	OpIteratorValue: "ITVAL",
 	OpBinaryOp:      "BINARYOP",
-	OpVarArgs:       "VARARGS",
 }
 
 // OpcodeOperands is the number of operands.
@@ -138,7 +136,6 @@ var OpcodeOperands = [...][]int{
 	OpIteratorKey:   {},
 	OpIteratorValue: {},
 	OpBinaryOp:      {1},
-	OpVarArgs:       {1},
 }
 
 // ReadOperands reads operands from the bytecode.

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -550,7 +550,7 @@ func (p *Parser) parseFuncType() *ast.FuncType {
 	}
 
 	pos := p.expect(token.Func)
-	params := p.parseIdentList(true)
+	params := p.parseIdentList()
 
 	return &ast.FuncType{
 		FuncPos: pos,
@@ -603,7 +603,7 @@ func (p *Parser) parseIdent() *ast.Ident {
 	}
 }
 
-func (p *Parser) parseIdentList(allowVarArgs bool) *ast.IdentList {
+func (p *Parser) parseIdentList() *ast.IdentList {
 	if p.trace {
 		defer un(trace(p, "IdentList"))
 	}
@@ -613,10 +613,6 @@ func (p *Parser) parseIdentList(allowVarArgs bool) *ast.IdentList {
 	isVarArgs := false
 	if p.token != token.RParen {
 		if p.token == token.Ellipsis {
-			if !allowVarArgs {
-				p.error(p.pos, "variable arguments are not permitted")
-			}
-
 			isVarArgs = true
 			p.next()
 		}
@@ -625,19 +621,11 @@ func (p *Parser) parseIdentList(allowVarArgs bool) *ast.IdentList {
 		for !isVarArgs && p.token == token.Comma {
 			p.next()
 			if p.token == token.Ellipsis {
-				if !allowVarArgs {
-					p.error(p.pos, "variable arguments are not permitted")
-				}
-
 				isVarArgs = true
 				p.next()
 			}
 			params = append(params, p.parseIdent())
 		}
-	}
-
-	if p.token == token.Comma {
-		p.error(p.pos, "variable argument must be last in list")
 	}
 
 	rparen := p.expect(token.RParen)

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -618,8 +618,8 @@ func (p *Parser) parseIdentList(allowVarArgs bool) *ast.IdentList {
 			}
 
 			isVarArgs = true
+			p.next()
 		}
-		p.next()
 
 		params = append(params, p.parseIdent())
 		if !isVarArgs {

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -622,13 +622,24 @@ func (p *Parser) parseIdentList(allowVarArgs bool) *ast.IdentList {
 		}
 
 		params = append(params, p.parseIdent())
-		if !isVarArgs {
-			for p.token == token.Comma {
+		for !isVarArgs && p.token == token.Comma {
+			p.next()
+			if p.token == token.Ellipsis {
+				if !allowVarArgs {
+					p.error(p.pos, "variable arguments are not permitted")
+				}
+
+				isVarArgs = true
 				p.next()
-				params = append(params, p.parseIdent())
 			}
+			params = append(params, p.parseIdent())
 		}
 	}
+
+	if p.token == token.Comma {
+		p.error(p.pos, "variable argument must be last in list")
+	}
+
 	rparen := p.expect(token.RParen)
 
 	return &ast.IdentList{

--- a/compiler/parser/parser_call_test.go
+++ b/compiler/parser/parser_call_test.go
@@ -90,6 +90,7 @@ func TestCall(t *testing.T) {
 						funcType(
 							identList(
 								p(1, 5), p(1, 10),
+								false,
 								ident("a", p(1, 6)),
 								ident("b", p(1, 9))),
 							p(1, 1)),

--- a/compiler/parser/parser_function_test.go
+++ b/compiler/parser/parser_function_test.go
@@ -29,7 +29,7 @@ func TestFunction(t *testing.T) {
 }
 
 func TestVariableFunction(t *testing.T) {
-	expect(t, "a = func(...args) { return args[0] }", func(p pfn) []ast.Stmt {
+	expect(t, "a = func(...args) { return args }", func(p pfn) []ast.Stmt {
 		return stmts(
 			assignStmt(
 				exprs(
@@ -42,13 +42,9 @@ func TestVariableFunction(t *testing.T) {
 								true,
 								ident("args", p(1, 13)),
 							), p(1, 5)),
-						blockStmt(p(1, 19), p(1, 36),
+						blockStmt(p(1, 19), p(1, 33),
 							returnStmt(p(1, 21),
-								indexExpr(
-									ident("args", p(1, 28)),
-									intLit(0, p(1, 33)),
-									p(1, 32), p(1, 34),
-								),
+								ident("args", p(1, 28)),
 							),
 						),
 					),
@@ -56,4 +52,35 @@ func TestVariableFunction(t *testing.T) {
 				token.Assign,
 				p(1, 3)))
 	})
+}
+
+func TestVariableFunctionWithArgs(t *testing.T) {
+	expect(t, "a = func(x, y, ...z) { return z }", func(p pfn) []ast.Stmt {
+		return stmts(
+			assignStmt(
+				exprs(
+					ident("a", p(1, 1))),
+				exprs(
+					funcLit(
+						funcType(
+							identList(
+								p(1, 9), p(1, 20),
+								true,
+								ident("x", p(1, 10)),
+								ident("y", p(1, 13)),
+								ident("z", p(1, 19)),
+							), p(1, 5)),
+						blockStmt(p(1, 22), p(1, 33),
+							returnStmt(p(1, 24),
+								ident("z", p(1, 31)),
+							),
+						),
+					),
+				),
+				token.Assign,
+				p(1, 3)))
+	})
+
+	expectError(t, "a = func(x, y, ...z, invalid) { return z }")
+	expectError(t, "a = func(...args, invalid) { return args }")
 }

--- a/compiler/parser/parser_function_test.go
+++ b/compiler/parser/parser_function_test.go
@@ -16,13 +16,43 @@ func TestFunction(t *testing.T) {
 				exprs(
 					funcLit(
 						funcType(
-							identList(p(1, 9), p(1, 17),
+							identList(p(1, 9), p(1, 17), false,
 								ident("b", p(1, 10)),
 								ident("c", p(1, 13)),
 								ident("d", p(1, 16))),
 							p(1, 5)),
 						blockStmt(p(1, 19), p(1, 30),
 							returnStmt(p(1, 21), ident("d", p(1, 28)))))),
+				token.Assign,
+				p(1, 3)))
+	})
+}
+
+func TestVariableFunction(t *testing.T) {
+	expect(t, "a = func(...args) { return args[0] }", func(p pfn) []ast.Stmt {
+		return stmts(
+			assignStmt(
+				exprs(
+					ident("a", p(1, 1))),
+				exprs(
+					funcLit(
+						funcType(
+							identList(
+								p(1, 9), p(1, 17),
+								true,
+								ident("args", p(1, 13)),
+							), p(1, 5)),
+						blockStmt(p(1, 19), p(1, 36),
+							returnStmt(p(1, 21),
+								indexExpr(
+									ident("args", p(1, 28)),
+									intLit(0, p(1, 33)),
+									p(1, 32), p(1, 34),
+								),
+							),
+						),
+					),
+				),
 				token.Assign,
 				p(1, 3)))
 	})

--- a/compiler/parser/parser_test.go
+++ b/compiler/parser/parser_test.go
@@ -180,8 +180,8 @@ func ident(name string, pos source.Pos) *ast.Ident {
 	return &ast.Ident{Name: name, NamePos: pos}
 }
 
-func identList(opening, closing source.Pos, list ...*ast.Ident) *ast.IdentList {
-	return &ast.IdentList{List: list, LParen: opening, RParen: closing}
+func identList(opening, closing source.Pos, varArgs bool, list ...*ast.Ident) *ast.IdentList {
+	return &ast.IdentList{VarArgs: varArgs, List: list, LParen: opening, RParen: closing}
 }
 
 func binaryExpr(x, y ast.Expr, op token.Token, pos source.Pos) *ast.BinaryExpr {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -154,6 +154,29 @@ func my_func(arg1, arg2) {  // illegal
 }
 ```
 
+Tengo also supports variadic functions/closures:
+
+```golang
+variadic := func (a, b, ...c) {
+  return [a, b, c]
+}
+variadic(1, 2, 3, 4) // [1, 2, [3, 4]]
+
+variadicClosure := func(a) {
+  return func(b, ...c) {
+    return [a, b, c]
+  }
+}
+variadicClosure(1)(2, 3, 4) // [1, 2, [3, 4]]
+```
+
+Only the last parameter can be variadic. The following code is also illegal:
+
+```golang
+// illegal, because a is variadic and is not the last parameter
+illegal := func(a..., b) { /*... */ }
+```
+
 ## Variables and Scopes
 
 A value can be assigned to a variable using assignment operator `:=` and `=`.

--- a/objects/compiled_function.go
+++ b/objects/compiled_function.go
@@ -10,6 +10,7 @@ type CompiledFunction struct {
 	Instructions  []byte
 	NumLocals     int // number of local variables (including function parameters)
 	NumParameters int
+	VarArgs       bool
 	SourceMap     map[int]source.Pos
 }
 
@@ -34,6 +35,7 @@ func (o *CompiledFunction) Copy() Object {
 		Instructions:  append([]byte{}, o.Instructions...),
 		NumLocals:     o.NumLocals,
 		NumParameters: o.NumParameters,
+		VarArgs:       o.VarArgs,
 	}
 }
 

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -646,16 +646,18 @@ func (v *VM) run() {
 				if callee.Fn.VarArgs {
 					passedArgs := numArgs
 					numArgs = 1
-
 					args := make([]objects.Object, 0, passedArgs)
-					for i := 0; i < passedArgs; i++ {
-						args = append(args, v.stack[v.sp-passedArgs+i])
-					}
 
-					v.stack[v.sp-passedArgs] = &objects.Array{Value: args}
+					if passedArgs == 0 {
+						v.stack[v.sp] = &objects.Array{Value: args}
+						v.sp++
+					} else {
+						for i := 0; i < passedArgs; i++ {
+							args = append(args, v.stack[v.sp-passedArgs+i])
+						}
 
-					for i := 1; i < passedArgs; i++ {
-						v.sp--
+						v.stack[v.sp-passedArgs] = &objects.Array{Value: args}
+						v.sp = v.sp - (passedArgs - 1)
 					}
 				}
 
@@ -695,16 +697,18 @@ func (v *VM) run() {
 				if callee.VarArgs {
 					passedArgs := numArgs
 					numArgs = 1
-
 					args := make([]objects.Object, 0, passedArgs)
-					for i := 0; i < passedArgs; i++ {
-						args = append(args, v.stack[v.sp-passedArgs+i])
-					}
 
-					v.stack[v.sp-passedArgs] = &objects.Array{Value: args}
+					if passedArgs == 0 {
+						v.stack[v.sp] = &objects.Array{Value: args}
+						v.sp++
+					} else {
+						for i := 0; i < passedArgs; i++ {
+							args = append(args, v.stack[v.sp-passedArgs+i])
+						}
 
-					for i := 1; i < passedArgs; i++ {
-						v.sp--
+						v.stack[v.sp-passedArgs] = &objects.Array{Value: args}
+						v.sp = v.sp - (passedArgs - 1)
 					}
 				}
 

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -647,21 +647,18 @@ func (v *VM) run() {
 					// roll up all variadic parameters into an array
 					realArgs := callee.Fn.NumParameters - 1
 					varArgs := numArgs - realArgs
-					if varArgs < 0 {
-						goto wrongNumberOfParametersClosure
+					if varArgs >= 0 {
+						numArgs = realArgs + 1
+						args := make([]objects.Object, varArgs)
+						spStart := v.sp - varArgs
+						for i := spStart; i < v.sp; i++ {
+							args[i-spStart] = v.stack[i]
+						}
+						v.stack[spStart] = &objects.Array{Value: args}
+						v.sp = spStart + 1
 					}
-					numArgs = realArgs + 1 // must come after varArgs check
-					args := make([]objects.Object, 0, varArgs)
-					spStart := v.sp - varArgs
-					for i := spStart; i < v.sp; i++ {
-						args = append(args, v.stack[i])
-					}
-
-					v.stack[spStart] = &objects.Array{Value: args}
-					v.sp = spStart + 1
 				}
 
-			wrongNumberOfParametersClosure:
 				if numArgs != callee.Fn.NumParameters {
 					if callee.Fn.VarArgs {
 						v.err = fmt.Errorf("wrong number of arguments: want>=%d, got=%d",
@@ -700,25 +697,22 @@ func (v *VM) run() {
 
 			case *objects.CompiledFunction:
 				if callee.VarArgs {
-					// if the function is variadic,
+					// if the closure is variadic,
 					// roll up all variadic parameters into an array
 					realArgs := callee.NumParameters - 1
 					varArgs := numArgs - realArgs
-					if varArgs < 0 {
-						goto wrongNumberOfParametersCompiledFunction
+					if varArgs >= 0 {
+						numArgs = realArgs + 1
+						args := make([]objects.Object, varArgs)
+						spStart := v.sp - varArgs
+						for i := spStart; i < v.sp; i++ {
+							args[i-spStart] = v.stack[i]
+						}
+						v.stack[spStart] = &objects.Array{Value: args}
+						v.sp = spStart + 1
 					}
-					numArgs = realArgs + 1 // has to come after the varArgs check
-					args := make([]objects.Object, 0, varArgs)
-					spStart := v.sp - varArgs
-					for i := spStart; i < v.sp; i++ {
-						args = append(args, v.stack[i])
-					}
-
-					v.stack[spStart] = &objects.Array{Value: args}
-					v.sp = spStart + 1
 				}
 
-			wrongNumberOfParametersCompiledFunction:
 				if numArgs != callee.NumParameters {
 					if callee.VarArgs {
 						v.err = fmt.Errorf("wrong number of arguments: want>=%d, got=%d",

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -642,6 +642,23 @@ func (v *VM) run() {
 
 			switch callee := value.(type) {
 			case *objects.Closure:
+				// consolidate args into an array
+				if callee.Fn.VarArgs {
+					passedArgs := numArgs
+					numArgs = 1
+
+					args := make([]objects.Object, 0, passedArgs)
+					for i := 0; i < passedArgs; i++ {
+						args = append(args, v.stack[v.sp-passedArgs+i])
+					}
+
+					v.stack[v.sp-passedArgs] = &objects.Array{Value: args}
+
+					for i := 1; i < passedArgs; i++ {
+						v.sp--
+					}
+				}
+
 				if numArgs != callee.Fn.NumParameters {
 					v.err = fmt.Errorf("wrong number of arguments: want=%d, got=%d",
 						callee.Fn.NumParameters, numArgs)
@@ -674,6 +691,23 @@ func (v *VM) run() {
 				v.sp = v.sp - numArgs + callee.Fn.NumLocals
 
 			case *objects.CompiledFunction:
+				// consolidate args into an array
+				if callee.VarArgs {
+					passedArgs := numArgs
+					numArgs = 1
+
+					args := make([]objects.Object, 0, passedArgs)
+					for i := 0; i < passedArgs; i++ {
+						args = append(args, v.stack[v.sp-passedArgs+i])
+					}
+
+					v.stack[v.sp-passedArgs] = &objects.Array{Value: args}
+
+					for i := 1; i < passedArgs; i++ {
+						v.sp--
+					}
+				}
+
 				if numArgs != callee.NumParameters {
 					v.err = fmt.Errorf("wrong number of arguments: want=%d, got=%d",
 						callee.NumParameters, numArgs)

--- a/runtime/vm_function_test.go
+++ b/runtime/vm_function_test.go
@@ -12,6 +12,12 @@ func TestFunction(t *testing.T) {
 	expect(t, `f1 := func() {}; f2 := func() { return f1(); }; f1(); out = f2();`, nil, objects.UndefinedValue)
 	expect(t, `f := func(x) { x; }; out = f(5);`, nil, objects.UndefinedValue)
 
+	expect(t, `f := func(...x) { return x; }; out = f(1,2,3);`, nil, &objects.Array{Value: []objects.Object{
+		&objects.Int{Value: 1},
+		&objects.Int{Value: 2},
+		&objects.Int{Value: 3},
+	}})
+
 	expect(t, `f := func(x) { return x; }; out = f(5);`, nil, 5)
 	expect(t, `f := func(x) { return x * 2; }; out = f(5);`, nil, 10)
 	expect(t, `f := func(x, y) { return x + y; }; out = f(5, 5);`, nil, 10)

--- a/runtime/vm_function_test.go
+++ b/runtime/vm_function_test.go
@@ -18,7 +18,31 @@ func TestFunction(t *testing.T) {
 		&objects.Int{Value: 3},
 	}})
 
+	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8,9,1,2,3);`, nil, &objects.Array{Value: []objects.Object{
+		&objects.Int{Value: 8},
+		&objects.Int{Value: 9},
+		&objects.Array{
+			Value: []objects.Object{
+				&objects.Int{Value: 1},
+				&objects.Int{Value: 2},
+				&objects.Int{Value: 3},
+			},
+		},
+	}})
+
 	expect(t, `f := func(...x) { return x; }; out = f();`, nil, &objects.Array{Value: []objects.Object{}})
+
+	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8, 9);`, nil, &objects.Array{Value: []objects.Object{
+		&objects.Int{Value: 8},
+		&objects.Int{Value: 9},
+		&objects.Array{Value: []objects.Object{}},
+	}})
+
+	expectError(t, `f := func(a, b, ...x) { return [a, b, x]; }; f();`, nil,
+		"Runtime Error: wrong number of arguments: want>=2, got=0\n\tat test:1:46")
+
+	expectError(t, `f := func(a, b, ...x) { return [a, b, x]; }; f(1);`, nil,
+		"Runtime Error: wrong number of arguments: want>=2, got=1\n\tat test:1:46")
 
 	expect(t, `f := func(x) { return x; }; out = f(5);`, nil, 5)
 	expect(t, `f := func(x) { return x * 2; }; out = f(5);`, nil, 10)

--- a/runtime/vm_function_test.go
+++ b/runtime/vm_function_test.go
@@ -18,6 +18,8 @@ func TestFunction(t *testing.T) {
 		&objects.Int{Value: 3},
 	}})
 
+	expect(t, `f := func(...x) { return x; }; out = f();`, nil, &objects.Array{Value: []objects.Object{}})
+
 	expect(t, `f := func(x) { return x; }; out = f(5);`, nil, 5)
 	expect(t, `f := func(x) { return x * 2; }; out = f(5);`, nil, 10)
 	expect(t, `f := func(x, y) { return x + y; }; out = f(5, 5);`, nil, 10)

--- a/runtime/vm_function_test.go
+++ b/runtime/vm_function_test.go
@@ -12,46 +12,20 @@ func TestFunction(t *testing.T) {
 	expect(t, `f1 := func() {}; f2 := func() { return f1(); }; f1(); out = f2();`, nil, objects.UndefinedValue)
 	expect(t, `f := func(x) { x; }; out = f(5);`, nil, objects.UndefinedValue)
 
-	expect(t, `f := func(...x) { return x; }; out = f(1,2,3);`, nil, &objects.Array{Value: []objects.Object{
-		&objects.Int{Value: 1},
-		&objects.Int{Value: 2},
-		&objects.Int{Value: 3},
-	}})
+	expect(t, `f := func(...x) { return x; }; out = f(1,2,3);`, nil, ARR{1, 2, 3})
 
-	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8,9,1,2,3);`, nil, &objects.Array{Value: []objects.Object{
-		&objects.Int{Value: 8},
-		&objects.Int{Value: 9},
-		&objects.Array{
-			Value: []objects.Object{
-				&objects.Int{Value: 1},
-				&objects.Int{Value: 2},
-				&objects.Int{Value: 3},
-			},
-		},
-	}})
+	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8,9,1,2,3);`, nil, ARR{8, 9, ARR{1, 2, 3}})
 
 	expect(t, `f := func(v) { x := 2; return func(a, ...b){ return [a, b, v+x]}; }; out = f(5)("a", "b");`, nil,
-		&objects.Array{Value: []objects.Object{
-			&objects.String{Value: "a"},
-			&objects.Array{Value: []objects.Object{&objects.String{Value: "b"}}},
-			&objects.Int{Value: 7},
-		}})
+		ARR{"a", ARR{"b"}, 7})
 
 	expect(t, `f := func(...x) { return x; }; out = f();`, nil, &objects.Array{Value: []objects.Object{}})
 
 	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8, 9);`, nil,
-		&objects.Array{Value: []objects.Object{
-			&objects.Int{Value: 8},
-			&objects.Int{Value: 9},
-			&objects.Array{Value: []objects.Object{}},
-		}})
+		ARR{8, 9, ARR{}})
 
 	expect(t, `f := func(v) { x := 2; return func(a, ...b){ return [a, b, v+x]}; }; out = f(5)("a");`, nil,
-		&objects.Array{Value: []objects.Object{
-			&objects.String{Value: "a"},
-			&objects.Array{Value: []objects.Object{}},
-			&objects.Int{Value: 7},
-		}})
+		ARR{"a", ARR{}, 7})
 
 	expectError(t, `f := func(a, b, ...x) { return [a, b, x]; }; f();`, nil,
 		"Runtime Error: wrong number of arguments: want>=2, got=0\n\tat test:1:46")

--- a/runtime/vm_function_test.go
+++ b/runtime/vm_function_test.go
@@ -30,13 +30,28 @@ func TestFunction(t *testing.T) {
 		},
 	}})
 
+	expect(t, `f := func(v) { x := 2; return func(a, ...b){ return [a, b, v+x]}; }; out = f(5)("a", "b");`, nil,
+		&objects.Array{Value: []objects.Object{
+			&objects.String{Value: "a"},
+			&objects.Array{Value: []objects.Object{&objects.String{Value: "b"}}},
+			&objects.Int{Value: 7},
+		}})
+
 	expect(t, `f := func(...x) { return x; }; out = f();`, nil, &objects.Array{Value: []objects.Object{}})
 
-	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8, 9);`, nil, &objects.Array{Value: []objects.Object{
-		&objects.Int{Value: 8},
-		&objects.Int{Value: 9},
-		&objects.Array{Value: []objects.Object{}},
-	}})
+	expect(t, `f := func(a, b, ...x) { return [a, b, x]; }; out = f(8, 9);`, nil,
+		&objects.Array{Value: []objects.Object{
+			&objects.Int{Value: 8},
+			&objects.Int{Value: 9},
+			&objects.Array{Value: []objects.Object{}},
+		}})
+
+	expect(t, `f := func(v) { x := 2; return func(a, ...b){ return [a, b, v+x]}; }; out = f(5)("a");`, nil,
+		&objects.Array{Value: []objects.Object{
+			&objects.String{Value: "a"},
+			&objects.Array{Value: []objects.Object{}},
+			&objects.Int{Value: 7},
+		}})
 
 	expectError(t, `f := func(a, b, ...x) { return [a, b, x]; }; f();`, nil,
 		"Runtime Error: wrong number of arguments: want>=2, got=0\n\tat test:1:46")


### PR DESCRIPTION
This is just an initial implementation of variable-argument functions. I'm expecting to need to make changes, but I wanted to demonstrate the initial approach and get feedback before going further.

With this implementation, there are two types of functions supported: regular (`func(a,b,c) {}`) and variadic (`func(...args) {}`). Currently, if a function is variadic, it must have exactly one argument. The VM is responsible for consolidating passed parameters when it processes an `OpCall` instruction on a `CompiledFunction` or `Closure` that is variadic. It does this by consolidating the arguments on the stack into an array, which is then stored on the stack in place of the original first argument. If no arguments are passed to a variadic function call, an empty array is added to the stack as the first argument.

