### PR TITLE
Callables

### DIFF
--- a/objects/array.go
+++ b/objects/array.go
@@ -129,3 +129,8 @@ func (o *Array) Iterate() Iterator {
 		l: len(o.Value),
 	}
 }
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *Array) CanIterate() bool {
+	return true
+}

--- a/objects/array.go
+++ b/objects/array.go
@@ -9,6 +9,7 @@ import (
 
 // Array represents an array of objects.
 type Array struct {
+	ObjectImpl
 	Value []Object
 }
 

--- a/objects/array_iterator.go
+++ b/objects/array_iterator.go
@@ -1,9 +1,8 @@
 package objects
 
-import "github.com/d5/tengo/compiler/token"
-
 // ArrayIterator is an iterator for an array.
 type ArrayIterator struct {
+	ObjectImpl
 	v []Object
 	i int
 	l int
@@ -16,17 +15,6 @@ func (i *ArrayIterator) TypeName() string {
 
 func (i *ArrayIterator) String() string {
 	return "<array-iterator>"
-}
-
-// BinaryOp returns another object that is the result of
-// a given binary operator and a right-hand side object.
-func (i *ArrayIterator) BinaryOp(op token.Token, rhs Object) (Object, error) {
-	return nil, ErrInvalidOperator
-}
-
-// IsFalsy returns true if the value of the type is falsy.
-func (i *ArrayIterator) IsFalsy() bool {
-	return true
 }
 
 // Equals returns true if the value of the type
@@ -54,14 +42,4 @@ func (i *ArrayIterator) Key() Object {
 // Value returns the value of the current element.
 func (i *ArrayIterator) Value() Object {
 	return i.v[i.i-1]
-}
-
-// IndexGet returns an element at a given index.
-func (i *ArrayIterator) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (i *ArrayIterator) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/array_iterator.go
+++ b/objects/array_iterator.go
@@ -17,6 +17,11 @@ func (i *ArrayIterator) String() string {
 	return "<array-iterator>"
 }
 
+// IsFalsy returns true if the value of the type is falsy.
+func (o *ArrayIterator) IsFalsy() bool {
+	return true
+}
+
 // Equals returns true if the value of the type
 // is equal to the value of another object.
 func (i *ArrayIterator) Equals(Object) bool {

--- a/objects/array_iterator.go
+++ b/objects/array_iterator.go
@@ -55,3 +55,13 @@ func (i *ArrayIterator) Key() Object {
 func (i *ArrayIterator) Value() Object {
 	return i.v[i.i-1]
 }
+
+// IndexGet returns an element at a given index.
+func (i *ArrayIterator) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (i *ArrayIterator) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/bool.go
+++ b/objects/bool.go
@@ -62,3 +62,13 @@ func (o *Bool) GobEncode() (b []byte, err error) {
 
 	return
 }
+
+// IndexGet returns an element at a given index.
+func (o *Bool) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *Bool) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/bool.go
+++ b/objects/bool.go
@@ -6,6 +6,7 @@ import (
 
 // Bool represents a boolean value.
 type Bool struct {
+	ObjectImpl
 	// this is intentionally non-public to force using objects.TrueValue and FalseValue always
 	value bool
 }
@@ -61,14 +62,4 @@ func (o *Bool) GobEncode() (b []byte, err error) {
 	}
 
 	return
-}
-
-// IndexGet returns an element at a given index.
-func (o *Bool) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *Bool) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/builtin_function.go
+++ b/objects/builtin_function.go
@@ -46,3 +46,8 @@ func (o *BuiltinFunction) Equals(x Object) bool {
 func (o *BuiltinFunction) Call(args ...Object) (Object, error) {
 	return o.Value(args...)
 }
+
+// CanCall returns whether the Object can be Called.
+func (o *BuiltinFunction) CanCall() bool {
+	return true
+}

--- a/objects/builtin_function.go
+++ b/objects/builtin_function.go
@@ -6,6 +6,7 @@ import (
 
 // BuiltinFunction represents a builtin function.
 type BuiltinFunction struct {
+	ObjectImpl
 	Name  string
 	Value CallableFunc
 }
@@ -44,14 +45,4 @@ func (o *BuiltinFunction) Equals(x Object) bool {
 // Call executes a builtin function.
 func (o *BuiltinFunction) Call(args ...Object) (Object, error) {
 	return o.Value(args...)
-}
-
-// IndexGet returns an element at a given index.
-func (o *BuiltinFunction) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *BuiltinFunction) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/builtin_function.go
+++ b/objects/builtin_function.go
@@ -45,3 +45,13 @@ func (o *BuiltinFunction) Equals(x Object) bool {
 func (o *BuiltinFunction) Call(args ...Object) (Object, error) {
 	return o.Value(args...)
 }
+
+// IndexGet returns an element at a given index.
+func (o *BuiltinFunction) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *BuiltinFunction) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/builtin_type_checks.go
+++ b/objects/builtin_type_checks.go
@@ -187,7 +187,7 @@ func builtinIsIterable(args ...Object) (Object, error) {
 		return nil, ErrWrongNumArguments
 	}
 
-	if iter := args[0].Iterate(); iter != nil {
+	if args[0].CanIterate() {
 		return TrueValue, nil
 	}
 

--- a/objects/builtin_type_checks.go
+++ b/objects/builtin_type_checks.go
@@ -187,7 +187,7 @@ func builtinIsIterable(args ...Object) (Object, error) {
 		return nil, ErrWrongNumArguments
 	}
 
-	if _, ok := args[0].(Iterable); ok {
+	if iter := args[0].Iterate(); iter != nil {
 		return TrueValue, nil
 	}
 

--- a/objects/builtin_type_checks.go
+++ b/objects/builtin_type_checks.go
@@ -174,8 +174,7 @@ func builtinIsCallable(args ...Object) (Object, error) {
 		return nil, ErrWrongNumArguments
 	}
 
-	switch args[0].(type) {
-	case *CompiledFunction, *Closure, Callable: // BuiltinFunction is Callable
+	if args[0].CanCall() {
 		return TrueValue, nil
 	}
 

--- a/objects/bytes.go
+++ b/objects/bytes.go
@@ -88,3 +88,8 @@ func (o *Bytes) Iterate() Iterator {
 		l: len(o.Value),
 	}
 }
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *Bytes) CanIterate() bool {
+	return true
+}

--- a/objects/bytes.go
+++ b/objects/bytes.go
@@ -80,6 +80,11 @@ func (o *Bytes) IndexGet(index Object) (res Object, err error) {
 	return
 }
 
+// IndexSet sets an element at a given index.
+func (o *Bytes) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}
+
 // Iterate creates a bytes iterator.
 func (o *Bytes) Iterate() Iterator {
 	return &BytesIterator{

--- a/objects/bytes.go
+++ b/objects/bytes.go
@@ -9,6 +9,7 @@ import (
 
 // Bytes represents a byte array.
 type Bytes struct {
+	ObjectImpl
 	Value []byte
 }
 
@@ -78,11 +79,6 @@ func (o *Bytes) IndexGet(index Object) (res Object, err error) {
 	res = &Int{Value: int64(o.Value[idxVal])}
 
 	return
-}
-
-// IndexSet sets an element at a given index.
-func (o *Bytes) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }
 
 // Iterate creates a bytes iterator.

--- a/objects/bytes_iterator.go
+++ b/objects/bytes_iterator.go
@@ -1,9 +1,8 @@
 package objects
 
-import "github.com/d5/tengo/compiler/token"
-
 // BytesIterator represents an iterator for a string.
 type BytesIterator struct {
+	ObjectImpl
 	v []byte
 	i int
 	l int
@@ -16,17 +15,6 @@ func (i *BytesIterator) TypeName() string {
 
 func (i *BytesIterator) String() string {
 	return "<bytes-iterator>"
-}
-
-// BinaryOp returns another object that is the result of
-// a given binary operator and a right-hand side object.
-func (i *BytesIterator) BinaryOp(op token.Token, rhs Object) (Object, error) {
-	return nil, ErrInvalidOperator
-}
-
-// IsFalsy returns true if the value of the type is falsy.
-func (i *BytesIterator) IsFalsy() bool {
-	return true
 }
 
 // Equals returns true if the value of the type
@@ -54,14 +42,4 @@ func (i *BytesIterator) Key() Object {
 // Value returns the value of the current element.
 func (i *BytesIterator) Value() Object {
 	return &Int{Value: int64(i.v[i.i-1])}
-}
-
-// IndexGet returns an element at a given index.
-func (i *BytesIterator) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (i *BytesIterator) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/bytes_iterator.go
+++ b/objects/bytes_iterator.go
@@ -55,3 +55,13 @@ func (i *BytesIterator) Key() Object {
 func (i *BytesIterator) Value() Object {
 	return &Int{Value: int64(i.v[i.i-1])}
 }
+
+// IndexGet returns an element at a given index.
+func (i *BytesIterator) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (i *BytesIterator) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/callable.go
+++ b/objects/callable.go
@@ -1,9 +1,0 @@
-package objects
-
-// Callable represents an object that can be called like a function.
-type Callable interface {
-	// Call should take an arbitrary number of arguments
-	// and returns a return value and/or an error,
-	// which the VM will consider as a run-time error.
-	Call(args ...Object) (ret Object, err error)
-}

--- a/objects/char.go
+++ b/objects/char.go
@@ -117,3 +117,13 @@ func (o *Char) Equals(x Object) bool {
 
 	return o.Value == t.Value
 }
+
+// IndexGet returns an element at a given index.
+func (o *Char) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *Char) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/char.go
+++ b/objects/char.go
@@ -6,6 +6,7 @@ import (
 
 // Char represents a character value.
 type Char struct {
+	ObjectImpl
 	Value rune
 }
 
@@ -116,14 +117,4 @@ func (o *Char) Equals(x Object) bool {
 	}
 
 	return o.Value == t.Value
-}
-
-// IndexGet returns an element at a given index.
-func (o *Char) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *Char) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/closure.go
+++ b/objects/closure.go
@@ -6,6 +6,7 @@ import (
 
 // Closure represents a function closure.
 type Closure struct {
+	ObjectImpl
 	Fn   *CompiledFunction
 	Free []*ObjectPtr
 }
@@ -42,14 +43,4 @@ func (o *Closure) IsFalsy() bool {
 // is equal to the value of another object.
 func (o *Closure) Equals(x Object) bool {
 	return false
-}
-
-// IndexGet returns an element at a given index.
-func (o *Closure) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *Closure) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/closure.go
+++ b/objects/closure.go
@@ -43,3 +43,13 @@ func (o *Closure) IsFalsy() bool {
 func (o *Closure) Equals(x Object) bool {
 	return false
 }
+
+// IndexGet returns an element at a given index.
+func (o *Closure) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *Closure) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/closure.go
+++ b/objects/closure.go
@@ -44,3 +44,8 @@ func (o *Closure) IsFalsy() bool {
 func (o *Closure) Equals(x Object) bool {
 	return false
 }
+
+// CanCall returns whether the Object can be Called.
+func (o *Closure) CanCall() bool {
+	return true
+}

--- a/objects/compiled_function.go
+++ b/objects/compiled_function.go
@@ -58,3 +58,13 @@ func (o *CompiledFunction) SourcePos(ip int) source.Pos {
 	}
 	return source.NoPos
 }
+
+// IndexGet returns an element at a given index.
+func (o *CompiledFunction) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *CompiledFunction) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/compiled_function.go
+++ b/objects/compiled_function.go
@@ -61,6 +61,13 @@ func (o *CompiledFunction) SourcePos(ip int) source.Pos {
 	return source.NoPos
 }
 
+// Call takes an arbitrary number of arguments
+// and returns a return value and/or an error.
 func (o *CompiledFunction) Call(args ...Object) (Object, error) {
 	return o.Fn(args...)
+}
+
+// CanCall returns whether the Object can be Called.
+func (o *CompiledFunction) CanCall() bool {
+	return true
 }

--- a/objects/compiled_function.go
+++ b/objects/compiled_function.go
@@ -12,6 +12,7 @@ type CompiledFunction struct {
 	NumLocals     int // number of local variables (including function parameters)
 	NumParameters int
 	SourceMap     map[int]source.Pos
+	Fn            CallableFunc // set by the runtime
 }
 
 // TypeName returns the name of the type.
@@ -58,4 +59,8 @@ func (o *CompiledFunction) SourcePos(ip int) source.Pos {
 		ip--
 	}
 	return source.NoPos
+}
+
+func (o *CompiledFunction) Call(args ...Object) (Object, error) {
+	return o.Fn(args...)
 }

--- a/objects/compiled_function.go
+++ b/objects/compiled_function.go
@@ -7,6 +7,7 @@ import (
 
 // CompiledFunction represents a compiled function.
 type CompiledFunction struct {
+	ObjectImpl
 	Instructions  []byte
 	NumLocals     int // number of local variables (including function parameters)
 	NumParameters int
@@ -57,14 +58,4 @@ func (o *CompiledFunction) SourcePos(ip int) source.Pos {
 		ip--
 	}
 	return source.NoPos
-}
-
-// IndexGet returns an element at a given index.
-func (o *CompiledFunction) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *CompiledFunction) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/error.go
+++ b/objects/error.go
@@ -8,6 +8,7 @@ import (
 
 // Error represents a string value.
 type Error struct {
+	ObjectImpl
 	Value Object
 }
 
@@ -56,9 +57,4 @@ func (o *Error) IndexGet(index Object) (res Object, err error) {
 
 	res = o.Value
 	return
-}
-
-// IndexSet sets an element at a given index.
-func (o *Error) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/error.go
+++ b/objects/error.go
@@ -49,8 +49,7 @@ func (o *Error) Equals(x Object) bool {
 
 // IndexGet returns an element at a given index.
 func (o *Error) IndexGet(index Object) (res Object, err error) {
-	strIdx, ok := ToString(index)
-	if !ok || strIdx != "value" {
+	if strIdx, _ := ToString(index); strIdx != "value" {
 		err = ErrInvalidIndexOnError
 		return
 	}

--- a/objects/error.go
+++ b/objects/error.go
@@ -45,3 +45,20 @@ func (o *Error) Copy() Object {
 func (o *Error) Equals(x Object) bool {
 	return o == x // pointer equality
 }
+
+// IndexGet returns an element at a given index.
+func (o *Error) IndexGet(index Object) (res Object, err error) {
+	strIdx, ok := ToString(index)
+	if !ok || strIdx != "value" {
+		err = ErrInvalidIndexOnError
+		return
+	}
+
+	res = o.Value
+	return
+}
+
+// IndexSet sets an element at a given index.
+func (o *Error) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/errors.go
+++ b/objects/errors.go
@@ -35,6 +35,9 @@ var ErrNotIndexable = errors.New("not indexable")
 // ErrNotIndexAssignable is an error where an Object is not index assignable.
 var ErrNotIndexAssignable = errors.New("not index-assignable")
 
+// ErrNotIndexAssignable is an error where an Object is not index assignable.
+var ErrNotImplemented = errors.New("not implemented")
+
 // ErrInvalidArgumentType represents an invalid argument value type error.
 type ErrInvalidArgumentType struct {
 	Name     string

--- a/objects/errors.go
+++ b/objects/errors.go
@@ -14,6 +14,9 @@ var ErrInvalidIndexType = errors.New("invalid index type")
 // ErrInvalidIndexValueType represents an invalid index value type.
 var ErrInvalidIndexValueType = errors.New("invalid index value type")
 
+// ErrInvalidIndexOnError represents an invalid index on error.
+var ErrInvalidIndexOnError = errors.New("invalid index on error")
+
 // ErrInvalidOperator represents an error for invalid operator usage.
 var ErrInvalidOperator = errors.New("invalid operator")
 
@@ -25,6 +28,12 @@ var ErrBytesLimit = errors.New("exceeding bytes size limit")
 
 // ErrStringLimit represents an error where the size of string value exceeds the limit.
 var ErrStringLimit = errors.New("exceeding string size limit")
+
+// ErrNotIndexable is an error where a given index is out of the bounds.
+var ErrNotIndexable = errors.New("not indexable")
+
+// ErrNotIndexable is an error where a given index is out of the bounds.
+var ErrNotIndexAssignable = errors.New("not index-assignable")
 
 // ErrInvalidArgumentType represents an invalid argument value type error.
 type ErrInvalidArgumentType struct {

--- a/objects/errors.go
+++ b/objects/errors.go
@@ -35,7 +35,7 @@ var ErrNotIndexable = errors.New("not indexable")
 // ErrNotIndexAssignable is an error where an Object is not index assignable.
 var ErrNotIndexAssignable = errors.New("not index-assignable")
 
-// ErrNotIndexAssignable is an error where an Object is not index assignable.
+// ErrNotImplemented is an error where an Object has not implemented a required method.
 var ErrNotImplemented = errors.New("not implemented")
 
 // ErrInvalidArgumentType represents an invalid argument value type error.

--- a/objects/errors.go
+++ b/objects/errors.go
@@ -29,10 +29,10 @@ var ErrBytesLimit = errors.New("exceeding bytes size limit")
 // ErrStringLimit represents an error where the size of string value exceeds the limit.
 var ErrStringLimit = errors.New("exceeding string size limit")
 
-// ErrNotIndexable is an error where a given index is out of the bounds.
+// ErrNotIndexable is an error where an Object is not indexable.
 var ErrNotIndexable = errors.New("not indexable")
 
-// ErrNotIndexable is an error where a given index is out of the bounds.
+// ErrNotIndexAssignable is an error where an Object is not index assignable.
 var ErrNotIndexAssignable = errors.New("not index-assignable")
 
 // ErrInvalidArgumentType represents an invalid argument value type error.

--- a/objects/float.go
+++ b/objects/float.go
@@ -144,3 +144,13 @@ func (o *Float) Equals(x Object) bool {
 
 	return o.Value == t.Value
 }
+
+// IndexGet returns an element at a given index.
+func (o *Float) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *Float) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/float.go
+++ b/objects/float.go
@@ -9,6 +9,7 @@ import (
 
 // Float represents a floating point number value.
 type Float struct {
+	ObjectImpl
 	Value float64
 }
 
@@ -143,14 +144,4 @@ func (o *Float) Equals(x Object) bool {
 	}
 
 	return o.Value == t.Value
-}
-
-// IndexGet returns an element at a given index.
-func (o *Float) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *Float) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/immutable_array.go
+++ b/objects/immutable_array.go
@@ -100,6 +100,11 @@ func (o *ImmutableArray) IndexGet(index Object) (res Object, err error) {
 	return
 }
 
+// IndexSet sets an element at a given index.
+func (o *ImmutableArray) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}
+
 // Iterate creates an array iterator.
 func (o *ImmutableArray) Iterate() Iterator {
 	return &ArrayIterator{

--- a/objects/immutable_array.go
+++ b/objects/immutable_array.go
@@ -108,3 +108,8 @@ func (o *ImmutableArray) Iterate() Iterator {
 		l: len(o.Value),
 	}
 }
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *ImmutableArray) CanIterate() bool {
+	return true
+}

--- a/objects/immutable_array.go
+++ b/objects/immutable_array.go
@@ -9,6 +9,7 @@ import (
 
 // ImmutableArray represents an immutable array of objects.
 type ImmutableArray struct {
+	ObjectImpl
 	Value []Object
 }
 
@@ -98,11 +99,6 @@ func (o *ImmutableArray) IndexGet(index Object) (res Object, err error) {
 	res = o.Value[idxVal]
 
 	return
-}
-
-// IndexSet sets an element at a given index.
-func (o *ImmutableArray) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }
 
 // Iterate creates an array iterator.

--- a/objects/immutable_map.go
+++ b/objects/immutable_map.go
@@ -9,6 +9,7 @@ import (
 
 // ImmutableMap represents an immutable map object.
 type ImmutableMap struct {
+	ObjectImpl
 	Value map[string]Object
 }
 
@@ -61,11 +62,6 @@ func (o *ImmutableMap) IndexGet(index Object) (res Object, err error) {
 	}
 
 	return
-}
-
-// IndexSet sets an element at a given index.
-func (o *ImmutableMap) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }
 
 // Equals returns true if the value of the type

--- a/objects/immutable_map.go
+++ b/objects/immutable_map.go
@@ -55,12 +55,17 @@ func (o *ImmutableMap) IndexGet(index Object) (res Object, err error) {
 		return
 	}
 
-	val, ok := o.Value[strIdx]
+	res, ok = o.Value[strIdx]
 	if !ok {
-		val = UndefinedValue
+		res = UndefinedValue
 	}
 
-	return val, nil
+	return
+}
+
+// IndexSet sets an element at a given index.
+func (o *ImmutableMap) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
 }
 
 // Equals returns true if the value of the type

--- a/objects/immutable_map.go
+++ b/objects/immutable_map.go
@@ -104,3 +104,8 @@ func (o *ImmutableMap) Iterate() Iterator {
 		l: len(keys),
 	}
 }
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *ImmutableMap) CanIterate() bool {
+	return true
+}

--- a/objects/index_assignable.go
+++ b/objects/index_assignable.go
@@ -1,9 +1,0 @@
-package objects
-
-// IndexAssignable is an object that can take an index and a value
-// on the left-hand side of the assignment statement.
-type IndexAssignable interface {
-	// IndexSet should take an index Object and a value Object.
-	// If an error is returned, it will be treated as a run-time error.
-	IndexSet(index, value Object) error
-}

--- a/objects/indexable.go
+++ b/objects/indexable.go
@@ -1,9 +1,0 @@
-package objects
-
-// Indexable is an object that can take an index and return an object.
-type Indexable interface {
-	// IndexGet should take an index Object and return a result Object or an error.
-	// If error is returned, the runtime will treat it as a run-time error and ignore returned value.
-	// If nil is returned as value, it will be converted to Undefined value by the runtime.
-	IndexGet(index Object) (value Object, err error)
-}

--- a/objects/int.go
+++ b/objects/int.go
@@ -196,3 +196,13 @@ func (o *Int) Equals(x Object) bool {
 
 	return o.Value == t.Value
 }
+
+// IndexGet returns an element at a given index.
+func (o *Int) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *Int) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/int.go
+++ b/objects/int.go
@@ -8,6 +8,7 @@ import (
 
 // Int represents an integer value.
 type Int struct {
+	ObjectImpl
 	Value int64
 }
 
@@ -116,13 +117,13 @@ func (o *Int) BinaryOp(op token.Token, rhs Object) (Object, error) {
 	case *Float:
 		switch op {
 		case token.Add:
-			return &Float{float64(o.Value) + rhs.Value}, nil
+			return &Float{Value: float64(o.Value) + rhs.Value}, nil
 		case token.Sub:
-			return &Float{float64(o.Value) - rhs.Value}, nil
+			return &Float{Value: float64(o.Value) - rhs.Value}, nil
 		case token.Mul:
-			return &Float{float64(o.Value) * rhs.Value}, nil
+			return &Float{Value: float64(o.Value) * rhs.Value}, nil
 		case token.Quo:
-			return &Float{float64(o.Value) / rhs.Value}, nil
+			return &Float{Value: float64(o.Value) / rhs.Value}, nil
 		case token.Less:
 			if float64(o.Value) < rhs.Value {
 				return TrueValue, nil
@@ -147,9 +148,9 @@ func (o *Int) BinaryOp(op token.Token, rhs Object) (Object, error) {
 	case *Char:
 		switch op {
 		case token.Add:
-			return &Char{rune(o.Value) + rhs.Value}, nil
+			return &Char{Value: rune(o.Value) + rhs.Value}, nil
 		case token.Sub:
-			return &Char{rune(o.Value) - rhs.Value}, nil
+			return &Char{Value: rune(o.Value) - rhs.Value}, nil
 		case token.Less:
 			if o.Value < int64(rhs.Value) {
 				return TrueValue, nil
@@ -195,14 +196,4 @@ func (o *Int) Equals(x Object) bool {
 	}
 
 	return o.Value == t.Value
-}
-
-// IndexGet returns an element at a given index.
-func (o *Int) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *Int) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/iterable.go
+++ b/objects/iterable.go
@@ -1,7 +1,0 @@
-package objects
-
-// Iterable represents an object that has iterator.
-type Iterable interface {
-	// Iterate should return an Iterator for the type.
-	Iterate() Iterator
-}

--- a/objects/map.go
+++ b/objects/map.go
@@ -9,6 +9,7 @@ import (
 
 // Map represents a map of objects.
 type Map struct {
+	ObjectImpl
 	Value map[string]Object
 }
 

--- a/objects/map.go
+++ b/objects/map.go
@@ -117,3 +117,8 @@ func (o *Map) Iterate() Iterator {
 		l: len(keys),
 	}
 }
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *Map) CanIterate() bool {
+	return true
+}

--- a/objects/map.go
+++ b/objects/map.go
@@ -82,12 +82,12 @@ func (o *Map) IndexGet(index Object) (res Object, err error) {
 		return
 	}
 
-	val, ok := o.Value[strIdx]
+	res, ok = o.Value[strIdx]
 	if !ok {
-		val = UndefinedValue
+		res = UndefinedValue
 	}
 
-	return val, nil
+	return
 }
 
 // IndexSet sets the value for the given key.

--- a/objects/map_iterator.go
+++ b/objects/map_iterator.go
@@ -4,6 +4,7 @@ import "github.com/d5/tengo/compiler/token"
 
 // MapIterator represents an iterator for the map.
 type MapIterator struct {
+	ObjectImpl
 	v map[string]Object
 	k []string
 	i int
@@ -59,14 +60,4 @@ func (i *MapIterator) Value() Object {
 	k := i.k[i.i-1]
 
 	return i.v[k]
-}
-
-// IndexGet returns an element at a given index.
-func (i *MapIterator) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (i *MapIterator) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/map_iterator.go
+++ b/objects/map_iterator.go
@@ -60,3 +60,13 @@ func (i *MapIterator) Value() Object {
 
 	return i.v[k]
 }
+
+// IndexGet returns an element at a given index.
+func (i *MapIterator) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (i *MapIterator) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/object.go
+++ b/objects/object.go
@@ -41,4 +41,57 @@ type Object interface {
 	// If Object is not index assignable, ErrNotIndexAssignable should be returned as error.
 	// If an error is returned, it will be treated as a run-time error.
 	IndexSet(index, value Object) error
+
+	// Iterate should return an Iterator for the type.
+	Iterate() Iterator
+}
+
+// ObjectImpl represents a default Object Implementation.
+type ObjectImpl struct {
+}
+
+// TypeName returns the name of the type.
+func (o *ObjectImpl) TypeName() string {
+	panic(ErrNotImplemented)
+}
+
+func (o *ObjectImpl) String() string {
+	panic(ErrNotImplemented)
+}
+
+// BinaryOp returns another object that is the result of
+// a given binary operator and a right-hand side object.
+func (o *ObjectImpl) BinaryOp(op token.Token, rhs Object) (Object, error) {
+	return nil, ErrInvalidOperator
+}
+
+// Copy returns a copy of the type.
+func (o *ObjectImpl) Copy() Object {
+	return nil
+}
+
+// IsFalsy returns true if the value of the type is falsy.
+func (o *ObjectImpl) IsFalsy() bool {
+	return true
+}
+
+// Equals returns true if the value of the type
+// is equal to the value of another object.
+func (o *ObjectImpl) Equals(x Object) bool {
+	return o == x
+}
+
+// IndexGet returns an element at a given index.
+func (o *ObjectImpl) IndexGet(index Object) (res Object, err error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *ObjectImpl) IndexSet(index, value Object) (err error) {
+	return ErrNotIndexAssignable
+}
+
+// Iterate returns an iterator.
+func (o *ObjectImpl) Iterate() Iterator {
+	return nil
 }

--- a/objects/object.go
+++ b/objects/object.go
@@ -63,15 +63,6 @@ type Object interface {
 type ObjectImpl struct {
 }
 
-// TypeName returns the name of the type.
-func (o *ObjectImpl) TypeName() string {
-	panic(ErrNotImplemented)
-}
-
-func (o *ObjectImpl) String() string {
-	panic(ErrNotImplemented)
-}
-
 // BinaryOp returns another object that is the result of
 // a given binary operator and a right-hand side object.
 func (o *ObjectImpl) BinaryOp(op token.Token, rhs Object) (Object, error) {
@@ -85,13 +76,13 @@ func (o *ObjectImpl) Copy() Object {
 
 // IsFalsy returns true if the value of the type is falsy.
 func (o *ObjectImpl) IsFalsy() bool {
-	return true
+	return false
 }
 
 // Equals returns true if the value of the type
 // is equal to the value of another object.
 func (o *ObjectImpl) Equals(x Object) bool {
-	return o == x
+	return false
 }
 
 // IndexGet returns an element at a given index.

--- a/objects/object.go
+++ b/objects/object.go
@@ -27,4 +27,18 @@ type Object interface {
 	// Copy function will be used for copy() builtin function
 	// which is expected to deep-copy the values generally.
 	Copy() Object
+
+	// IndexGet should take an index Object and return a result Object or an error for indexable objects.
+	// Indexable is an object that can take an index and return an object.
+	// If error is returned, the runtime will treat it as a run-time error and ignore returned value.
+	// If Object is not indexable, ErrNotIndexable should be returned as error.
+	// If nil is returned as value, it will be converted to Undefined value by the runtime.
+	IndexGet(index Object) (value Object, err error)
+
+	// IndexSet should take an index Object and a value Object for index assignable objects.
+	// Index assignable is an object that can take an index and a value
+	// on the left-hand side of the assignment statement.
+	// If Object is not index assignable, ErrNotIndexAssignable should be returned as error.
+	// If an error is returned, it will be treated as a run-time error.
+	IndexSet(index, value Object) error
 }

--- a/objects/object.go
+++ b/objects/object.go
@@ -44,6 +44,9 @@ type Object interface {
 
 	// Iterate should return an Iterator for the type.
 	Iterate() Iterator
+
+	// CanIterate should return whether the Object can be Iterated.
+	CanIterate() bool
 }
 
 // ObjectImpl represents a default Object Implementation.
@@ -94,4 +97,9 @@ func (o *ObjectImpl) IndexSet(index, value Object) (err error) {
 // Iterate returns an iterator.
 func (o *ObjectImpl) Iterate() Iterator {
 	return nil
+}
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *ObjectImpl) CanIterate() bool {
+	return false
 }

--- a/objects/object.go
+++ b/objects/object.go
@@ -47,6 +47,14 @@ type Object interface {
 
 	// CanIterate should return whether the Object can be Iterated.
 	CanIterate() bool
+
+	// Call should take an arbitrary number of arguments
+	// and returns a return value and/or an error,
+	// which the VM will consider as a run-time error.
+	Call(args ...Object) (ret Object, err error)
+
+	// CanCall should return whether the Object can be Called.
+	CanCall() bool
 }
 
 // ObjectImpl represents a default Object Implementation.
@@ -101,5 +109,16 @@ func (o *ObjectImpl) Iterate() Iterator {
 
 // CanIterate returns whether the Object can be Iterated.
 func (o *ObjectImpl) CanIterate() bool {
+	return false
+}
+
+// Call takes an arbitrary number of arguments
+// and returns a return value and/or an error.
+func (o *ObjectImpl) Call(args ...Object) (ret Object, err error) {
+	return nil, nil
+}
+
+// CanCall returns whether the Object can be Called.
+func (o *ObjectImpl) CanCall() bool {
 	return false
 }

--- a/objects/object.go
+++ b/objects/object.go
@@ -57,7 +57,9 @@ type Object interface {
 	CanCall() bool
 }
 
-// ObjectImpl represents a default Object Implementation.
+// ObjectImpl represents a default Object Implementation. To defined a new value type,
+// one can embed ObjectImpl in their type declarations to avoid implementing all non-significant
+// methods. TypeName() and String() methods still need to be implemented.
 type ObjectImpl struct {
 }
 

--- a/objects/object_ptr.go
+++ b/objects/object_ptr.go
@@ -1,11 +1,8 @@
 package objects
 
-import (
-	"github.com/d5/tengo/compiler/token"
-)
-
 // ObjectPtr represents a free variable.
 type ObjectPtr struct {
+	ObjectImpl
 	Value *Object
 }
 
@@ -16,12 +13,6 @@ func (o *ObjectPtr) String() string {
 // TypeName returns the name of the type.
 func (o *ObjectPtr) TypeName() string {
 	return "<free-var>"
-}
-
-// BinaryOp returns another object that is the result of
-// a given binary operator and a right-hand side object.
-func (o *ObjectPtr) BinaryOp(op token.Token, rhs Object) (Object, error) {
-	return nil, ErrInvalidOperator
 }
 
 // Copy returns a copy of the type.
@@ -38,14 +29,4 @@ func (o *ObjectPtr) IsFalsy() bool {
 // is equal to the value of another object.
 func (o *ObjectPtr) Equals(x Object) bool {
 	return o == x
-}
-
-// IndexGet returns an element at a given index.
-func (o *ObjectPtr) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *ObjectPtr) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/object_ptr.go
+++ b/objects/object_ptr.go
@@ -39,3 +39,13 @@ func (o *ObjectPtr) IsFalsy() bool {
 func (o *ObjectPtr) Equals(x Object) bool {
 	return o == x
 }
+
+// IndexGet returns an element at a given index.
+func (o *ObjectPtr) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *ObjectPtr) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/string.go
+++ b/objects/string.go
@@ -9,6 +9,7 @@ import (
 
 // String represents a string value.
 type String struct {
+	ObjectImpl
 	Value   string
 	runeStr []rune
 }
@@ -88,11 +89,6 @@ func (o *String) IndexGet(index Object) (res Object, err error) {
 	res = &Char{Value: o.runeStr[idxVal]}
 
 	return
-}
-
-// IndexSet sets an element at a given index.
-func (o *String) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }
 
 // Iterate creates a string iterator.

--- a/objects/string.go
+++ b/objects/string.go
@@ -102,3 +102,8 @@ func (o *String) Iterate() Iterator {
 		l: len(o.runeStr),
 	}
 }
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *String) CanIterate() bool {
+	return true
+}

--- a/objects/string.go
+++ b/objects/string.go
@@ -90,6 +90,11 @@ func (o *String) IndexGet(index Object) (res Object, err error) {
 	return
 }
 
+// IndexSet sets an element at a given index.
+func (o *String) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}
+
 // Iterate creates a string iterator.
 func (o *String) Iterate() Iterator {
 	if o.runeStr == nil {

--- a/objects/string_iterator.go
+++ b/objects/string_iterator.go
@@ -4,6 +4,7 @@ import "github.com/d5/tengo/compiler/token"
 
 // StringIterator represents an iterator for a string.
 type StringIterator struct {
+	ObjectImpl
 	v []rune
 	i int
 	l int
@@ -54,14 +55,4 @@ func (i *StringIterator) Key() Object {
 // Value returns the value of the current element.
 func (i *StringIterator) Value() Object {
 	return &Char{Value: i.v[i.i-1]}
-}
-
-// IndexGet returns an element at a given index.
-func (i *StringIterator) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (i *StringIterator) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/string_iterator.go
+++ b/objects/string_iterator.go
@@ -55,3 +55,13 @@ func (i *StringIterator) Key() Object {
 func (i *StringIterator) Value() Object {
 	return &Char{Value: i.v[i.i-1]}
 }
+
+// IndexGet returns an element at a given index.
+func (i *StringIterator) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (i *StringIterator) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/time.go
+++ b/objects/time.go
@@ -8,6 +8,7 @@ import (
 
 // Time represents a time value.
 type Time struct {
+	ObjectImpl
 	Value time.Time
 }
 
@@ -86,14 +87,4 @@ func (o *Time) Equals(x Object) bool {
 	}
 
 	return o.Value.Equal(t.Value)
-}
-
-// IndexGet returns an element at a given index.
-func (o *Time) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *Time) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/time.go
+++ b/objects/time.go
@@ -87,3 +87,13 @@ func (o *Time) Equals(x Object) bool {
 
 	return o.Value.Equal(t.Value)
 }
+
+// IndexGet returns an element at a given index.
+func (o *Time) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *Time) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/objects/undefined.go
+++ b/objects/undefined.go
@@ -3,7 +3,9 @@ package objects
 import "github.com/d5/tengo/compiler/token"
 
 // Undefined represents an undefined value.
-type Undefined struct{}
+type Undefined struct {
+	ObjectImpl
+}
 
 // TypeName returns the name of the type.
 func (o *Undefined) TypeName() string {
@@ -39,29 +41,4 @@ func (o *Undefined) Equals(x Object) bool {
 // IndexGet returns an element at a given index.
 func (o *Undefined) IndexGet(index Object) (Object, error) {
 	return UndefinedValue, nil
-}
-
-// IndexSet sets an element at a given index.
-func (o *Undefined) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
-}
-
-// Iterate creates a map iterator.
-func (o *Undefined) Iterate() Iterator {
-	return o
-}
-
-// Next returns true if there are more elements to iterate.
-func (o *Undefined) Next() bool {
-	return false
-}
-
-// Key returns the key or index value of the current element.
-func (o *Undefined) Key() Object {
-	return o
-}
-
-// Value returns the value of the current element.
-func (o *Undefined) Value() Object {
-	return o
 }

--- a/objects/undefined.go
+++ b/objects/undefined.go
@@ -41,6 +41,11 @@ func (o *Undefined) IndexGet(index Object) (Object, error) {
 	return UndefinedValue, nil
 }
 
+// IndexSet sets an element at a given index.
+func (o *Undefined) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}
+
 // Iterate creates a map iterator.
 func (o *Undefined) Iterate() Iterator {
 	return o

--- a/objects/undefined.go
+++ b/objects/undefined.go
@@ -42,3 +42,28 @@ func (o *Undefined) Equals(x Object) bool {
 func (o *Undefined) IndexGet(index Object) (Object, error) {
 	return UndefinedValue, nil
 }
+
+// Iterate creates a map iterator.
+func (o *Undefined) Iterate() Iterator {
+	return o
+}
+
+// CanIterate returns whether the Object can be Iterated.
+func (o *Undefined) CanIterate() bool {
+	return true
+}
+
+// Next returns true if there are more elements to iterate.
+func (o *Undefined) Next() bool {
+	return false
+}
+
+// Key returns the key or index value of the current element.
+func (o *Undefined) Key() Object {
+	return o
+}
+
+// Value returns the value of the current element.
+func (o *Undefined) Value() Object {
+	return o
+}

--- a/objects/user_function.go
+++ b/objects/user_function.go
@@ -47,3 +47,8 @@ func (o *UserFunction) Equals(x Object) bool {
 func (o *UserFunction) Call(args ...Object) (Object, error) {
 	return o.Value(args...)
 }
+
+// CanCall returns whether the Object can be Called.
+func (o *UserFunction) CanCall() bool {
+	return true
+}

--- a/objects/user_function.go
+++ b/objects/user_function.go
@@ -6,6 +6,7 @@ import (
 
 // UserFunction represents a user function.
 type UserFunction struct {
+	ObjectImpl
 	Name       string
 	Value      CallableFunc
 	EncodingID string
@@ -45,14 +46,4 @@ func (o *UserFunction) Equals(x Object) bool {
 // Call invokes a user function.
 func (o *UserFunction) Call(args ...Object) (Object, error) {
 	return o.Value(args...)
-}
-
-// IndexGet returns an element at a given index.
-func (o *UserFunction) IndexGet(index Object) (Object, error) {
-	return nil, ErrNotIndexable
-}
-
-// IndexSet sets an element at a given index.
-func (o *UserFunction) IndexSet(index, value Object) error {
-	return ErrNotIndexAssignable
 }

--- a/objects/user_function.go
+++ b/objects/user_function.go
@@ -46,3 +46,13 @@ func (o *UserFunction) Equals(x Object) bool {
 func (o *UserFunction) Call(args ...Object) (Object, error) {
 	return o.Value(args...)
 }
+
+// IndexGet returns an element at a given index.
+func (o *UserFunction) IndexGet(index Object) (Object, error) {
+	return nil, ErrNotIndexable
+}
+
+// IndexSet sets an element at a given index.
+func (o *UserFunction) IndexSet(index, value Object) error {
+	return ErrNotIndexAssignable
+}

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -421,19 +421,19 @@ func (v *VM) run() {
 			left := v.stack[v.sp-2]
 			v.sp -= 2
 
-			val, e := left.IndexGet(index)
-			if e != nil {
-				if e == objects.ErrNotIndexable {
+			val, err := left.IndexGet(index)
+			if err != nil {
+				if err == objects.ErrNotIndexable {
 					v.err = fmt.Errorf("not indexable: %s", index.TypeName())
 					return
 				}
 
-				if e == objects.ErrInvalidIndexType {
+				if err == objects.ErrInvalidIndexType {
 					v.err = fmt.Errorf("invalid index type: %s", index.TypeName())
 					return
 				}
 
-				v.err = e
+				v.err = err
 				return
 			}
 
@@ -935,13 +935,11 @@ func (v *VM) run() {
 			dst := v.stack[v.sp-1]
 			v.sp--
 
-			iterable, ok := dst.(objects.Iterable)
-			if !ok {
+			iterator = dst.Iterate()
+			if iterator == nil {
 				v.err = fmt.Errorf("not iterable: %s", dst.TypeName())
 				return
 			}
-
-			iterator = iterable.Iterate()
 
 			v.allocs--
 			if v.allocs == 0 {

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -651,6 +651,11 @@ func (v *VM) runFrame(numArgs int, fn *objects.CompiledFunction, freeVars []*obj
 
 			value := v.stack[v.sp-1-numArgs]
 
+			if !value.CanCall() {
+				err = fmt.Errorf("not callable: %s", value.TypeName())
+				return
+			}
+
 			switch callee := value.(type) {
 			case *objects.Closure:
 				if numArgs != callee.Fn.NumParameters {
@@ -714,7 +719,7 @@ func (v *VM) runFrame(numArgs int, fn *objects.CompiledFunction, freeVars []*obj
 				v.stack[v.sp] = retVal
 				v.sp++
 
-			case objects.Callable:
+			default:
 				var args []objects.Object
 				args = append(args, v.stack[v.sp-numArgs:v.sp]...)
 
@@ -752,10 +757,6 @@ func (v *VM) runFrame(numArgs int, fn *objects.CompiledFunction, freeVars []*obj
 
 				v.stack[v.sp] = retVal
 				v.sp++
-
-			default:
-				err = fmt.Errorf("not callable: %s", callee.TypeName())
-				return
 			}
 
 		case compiler.OpReturn:

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -952,12 +952,12 @@ func (v *VM) runFrame(numArgs int, fn *objects.CompiledFunction, freeVars []*obj
 			dst := v.stack[v.sp-1]
 			v.sp--
 
-			iterator = dst.Iterate()
-			if iterator == nil {
+			if !dst.CanIterate() {
 				err = fmt.Errorf("not iterable: %s", dst.TypeName())
 				return
 			}
 
+			iterator = dst.Iterate()
 			v.allocs--
 			if v.allocs == 0 {
 				err = ErrObjectAllocLimit

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -135,7 +135,6 @@ func (v *VM) runFrame(numArgs int, fn *objects.CompiledFunction, freeVars []*obj
 	v.curFrame.fn = fn
 	v.curFrame.freeVars = freeVars
 	v.curFrame.basePointer = v.sp - numArgs
-	v.curInsts = fn.Instructions
 	v.ip = -1
 	v.framesIndex++
 	v.sp = v.sp - numArgs + fn.NumLocals

--- a/runtime/vm.go
+++ b/runtime/vm.go
@@ -704,7 +704,7 @@ func (v *VM) runFrame(numArgs int, fn *objects.CompiledFunction, freeVars []*obj
 					}
 				}
 
-				retVal, e := callee.Call()
+				retVal, e := v.runFrame(numArgs, callee, nil)
 				if e != nil {
 					err = e
 					return

--- a/runtime/vm_indexable_test.go
+++ b/runtime/vm_indexable_test.go
@@ -226,6 +226,10 @@ func (o *StringArray) Call(args ...objects.Object) (ret objects.Object, err erro
 	return objects.UndefinedValue, nil
 }
 
+func (o *StringArray) CanCall() bool {
+	return true
+}
+
 func TestIndexable(t *testing.T) {
 	dict := func() *StringDict { return &StringDict{Value: map[string]string{"a": "foo", "b": "bar"}} }
 	expect(t, `out = dict["a"]`, Opts().Symbol("dict", dict()).Skip2ndPass(), "foo")

--- a/runtime/vm_indexable_test.go
+++ b/runtime/vm_indexable_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/d5/tengo/objects"
 )
 
-type objectImpl struct{}
+type objectImpl struct {
+	objects.ObjectImpl
+}
 
 func (objectImpl) TypeName() string                   { return "" }
 func (objectImpl) String() string                     { return "" }

--- a/runtime/vm_indexable_test.go
+++ b/runtime/vm_indexable_test.go
@@ -106,6 +106,7 @@ func (o *StringCircle) IndexSet(index, value objects.Object) error {
 }
 
 type StringArray struct {
+	objects.ObjectImpl
 	Value []string
 }
 

--- a/runtime/vm_iterable_test.go
+++ b/runtime/vm_iterable_test.go
@@ -35,6 +35,10 @@ func (o *StringArray) Iterate() objects.Iterator {
 	}
 }
 
+func (o *StringArray) CanIterate() bool {
+	return true
+}
+
 func TestIterable(t *testing.T) {
 	strArr := func() *StringArray { return &StringArray{Value: []string{"one", "two", "three"}} }
 

--- a/runtime/vm_iterable_test.go
+++ b/runtime/vm_iterable_test.go
@@ -29,14 +29,6 @@ func (i *StringArrayIterator) Value() objects.Object {
 	return &objects.String{Value: i.strArr.Value[i.idx-1]}
 }
 
-func (o *StringArrayIterator) IndexGet(index objects.Object) (objects.Object, error) {
-	return nil, objects.ErrNotIndexable
-}
-
-func (o *StringArrayIterator) IndexSet(index, value objects.Object) error {
-	return objects.ErrNotIndexAssignable
-}
-
 func (o *StringArray) Iterate() objects.Iterator {
 	return &StringArrayIterator{
 		strArr: o,

--- a/runtime/vm_iterable_test.go
+++ b/runtime/vm_iterable_test.go
@@ -29,6 +29,14 @@ func (i *StringArrayIterator) Value() objects.Object {
 	return &objects.String{Value: i.strArr.Value[i.idx-1]}
 }
 
+func (o *StringArrayIterator) IndexGet(index objects.Object) (objects.Object, error) {
+	return nil, objects.ErrNotIndexable
+}
+
+func (o *StringArrayIterator) IndexSet(index, value objects.Object) error {
+	return objects.ErrNotIndexAssignable
+}
+
 func (o *StringArray) Iterate() objects.Iterator {
 	return &StringArrayIterator{
 		strArr: o,

--- a/script/script_bench_test.go
+++ b/script/script_bench_test.go
@@ -1,0 +1,37 @@
+package script_test
+
+import (
+    "testing"
+
+    "github.com/d5/tengo/script"
+)
+
+func BenchmarkArrayIndex(b *testing.B) {
+    bench(b.N, `a := [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        for i := 0; i < 1000; i++ {
+            a[0]; a[1]; a[2]; a[3]; a[4]; a[5]; a[6]; a[7]; a[7];
+        }
+    `)
+}
+
+func BenchmarkArrayIndexCompare(b *testing.B) {
+    bench(b.N, `a := [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        for i := 0; i < 1000; i++ {
+            1; 2; 3; 4; 5; 6; 7; 8; 9;
+        }
+    `)
+}
+
+func bench(n int, input string) {
+    s := script.New([]byte(input))
+    c, err := s.Compile()
+    if err != nil {
+        panic(err)
+    }
+
+    for i := 0; i < n; i++ {
+        if err := c.Run(); err != nil {
+            panic(err)
+        }
+    }
+}

--- a/script/script_custom_test.go
+++ b/script/script_custom_test.go
@@ -65,6 +65,10 @@ func (o *Counter) Call(args ...objects.Object) (objects.Object, error) {
 	return &objects.Int{Value: o.value}, nil
 }
 
+func (o *Counter) CanCall() bool {
+	return true
+}
+
 func TestScript_CustomObjects(t *testing.T) {
 	c := compile(t, `a := c1(); s := string(c1); c2 := c1; c2++`, M{
 		"c1": &Counter{value: 5},

--- a/script/script_custom_test.go
+++ b/script/script_custom_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 type Counter struct {
+	objects.ObjectImpl
 	value int64
 }
 
@@ -62,14 +63,6 @@ func (o *Counter) Copy() objects.Object {
 
 func (o *Counter) Call(args ...objects.Object) (objects.Object, error) {
 	return &objects.Int{Value: o.value}, nil
-}
-
-func (o *Counter) IndexGet(index objects.Object) (objects.Object, error) {
-	return nil, objects.ErrNotIndexable
-}
-
-func (o *Counter) IndexSet(index, value objects.Object) error {
-	return objects.ErrNotIndexAssignable
 }
 
 func TestScript_CustomObjects(t *testing.T) {

--- a/script/script_custom_test.go
+++ b/script/script_custom_test.go
@@ -64,6 +64,14 @@ func (o *Counter) Call(args ...objects.Object) (objects.Object, error) {
 	return &objects.Int{Value: o.value}, nil
 }
 
+func (o *Counter) IndexGet(index objects.Object) (objects.Object, error) {
+	return nil, objects.ErrNotIndexable
+}
+
+func (o *Counter) IndexSet(index, value objects.Object) error {
+	return objects.ErrNotIndexAssignable
+}
+
 func TestScript_CustomObjects(t *testing.T) {
 	c := compile(t, `a := c1(); s := string(c1); c2 := c1; c2++`, M{
 		"c1": &Counter{value: 5},


### PR DESCRIPTION
PR for reference (for now).

- I don't think moving `Callable` into `Object` a good idea because type checking whether an `Object` is "callable" is not possible if we keep the current signature of the `Call(args ...Object) (ret Object, err error)` without actually calling the object. It's not the best idea to actually do a call just to type check callability. We'd have to add an additional method like `IsCallable()` which adds unnecessary complexity to `Object`.
- The feature makes something like fib(35) 10% slower due to the additional complexity involved in running each call of a function.

I am not entirely sure if the performance can be improved, but I think it would allow `CompiledFunction` and `Closure` to be callable from Go. I have no use for a use case like this, especially not given the performance downside, but if the performance can be improved it might be worth implementing.
