### PR TITLE
Error handling between Go and Tengo interops

### DIFF
--- a/runtime/vm_call_from_go_test.go
+++ b/runtime/vm_call_from_go_test.go
@@ -156,13 +156,13 @@ func TestCallFromGo(t *testing.T) {
 		out = call_from_go(format, "%d %d %d", 1, 2, 3)
 	`, "1 2 3")
 
-	interopExpectError(t, `
+	interopExpect(t, `
 		fn := func() {
 			return 5/[]
 		}
 
 		out = call_from_go_noerr(fn)
-	`, "Runtime Error: invalid operation: int / array")
+	`, objects.UndefinedValue)
 
 	interopExpectError(t, `
 		fn := func(a, b, c) { return [a,b,c]; }


### PR DESCRIPTION
- Calling Stack
  - **[(0) User]** --_VM.Run_--> 
    - **[(1) VM]** --_OpCall_--> 
      -  **[(2) Go]** --_VM.Call_--> 
          - **[(3) VM]** ->
      - **[(2) Go]** -> 
    - **[(1) VM]** -> 
  - **[(0) User]**

Scenarios:
- [ ] Go function (2) returns an error: VM (1) will treat it as a runtime error and stop its execution.
- [ ] Go function (2) panics: VM (1) will not do anything about it and the panic will be propagated back to the calling user (0).
- [ ] VM (3) returns an error:
    - Go function (2) returns the error (directly or wrapped) back to VM (1), which will treat it as a runtime error and stop its execution.
    - Go function (2) ignores or swallows the error: VM (1) still be able to continue its execution as if nothing happened.
- [ ] VM (3) panics
    - If Go function (2) does not capture (`recover`) or rethrow: VM (1) should not do anything about it, and, the panic should be propagated back to the calling user. 
    - If Go function (2) ignores/swallow the panic and proceeds: VM (1) should not execute anything and propagate the last panic back to the calling user.

This PR is not complete. Test does not pass.