### PR TITLE
support json.Number as string

### DIFF
--- a/objects/conversion.go
+++ b/objects/conversion.go
@@ -1,6 +1,7 @@
 package objects
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -219,6 +220,11 @@ func FromInterface(v interface{}) (Object, error) {
 		return &String{Value: v}, nil
 	case int64:
 		return &Int{Value: v}, nil
+	case json.Number:
+		if len(v) > tengo.MaxStringLen {
+			return nil, ErrStringLimit
+		}
+		return &String{Value: string(v)}, nil
 	case int:
 		return &Int{Value: int64(v)}, nil
 	case bool:

--- a/script/compiled.go
+++ b/script/compiled.go
@@ -77,6 +77,25 @@ func (c *Compiled) Clone() *Compiled {
 	return clone
 }
 
+// Lock is unnecessary when copy exist struct concurrently
+func (c *Compiled) CloneWithoutLock() *Compiled {
+	clone := &Compiled{
+		globalIndexes: c.globalIndexes,
+		bytecode:      c.bytecode,
+		globals:       make([]objects.Object, len(c.globals)),
+		maxAllocs:     c.maxAllocs,
+	}
+
+	// copy global objects
+	for idx, g := range c.globals {
+		if g != nil {
+			clone.globals[idx] = g
+		}
+	}
+
+	return clone
+}
+
 // IsDefined returns true if the variable name is defined (has value) before or after the execution.
 func (c *Compiled) IsDefined(name string) bool {
 	c.lock.RLock()


### PR DESCRIPTION
json.Number is an alias for string

tengo will throw `cannot convert to object` when meet json.Number
