### PR TITLE
remove callable args alloc

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -604,9 +604,7 @@ func (v *VM) run() {
 				v.framesIndex++
 				v.sp = v.sp - numArgs + callee.NumLocals
 			} else {
-				var args []Object
-				args = append(args, v.stack[v.sp-numArgs:v.sp]...)
-				ret, e := value.Call(args...)
+				ret, e := value.Call(v.stack[v.sp-numArgs : v.sp]...)
 				v.sp -= numArgs + 1
 
 				// runtime error


### PR DESCRIPTION
Removing slice allocation for callable arguments improves speed and allocation if arguments are provided to callable. Benchmark results are provided below. This makes sense for me because I run more than ten thousand of tengo scripts in a second. Let me know if benchmark is wrong or if I missed a point.
[Gist for bechmark](https://gist.github.com/ozanh/368c6383b4e5a90246a829e85217abd2)

Current
```
goos: linux
goarch: amd64
pkg: github.com/d5/tengo/v2
BenchmarkCallAlloc/NoArg        11966798                90.0 ns/op             8 B/op          1 allocs/op
BenchmarkCallAlloc/1Arg          8135835               148 ns/op              24 B/op          2 allocs/op
BenchmarkCallAlloc/2Arg          6741585               177 ns/op              40 B/op          2 allocs/op
```

After removing slice allocation
```
goarch: amd64
pkg: github.com/d5/tengo/v2
BenchmarkCallAlloc/NoArg                14734291                88.1 ns/op             8 B/op          1 allocs/op
BenchmarkCallAlloc/1Arg                 12089188                88.0 ns/op             8 B/op          1 allocs/op
BenchmarkCallAlloc/2Arg                 13995144                89.4 ns/op             8 B/op          1 allocs/op
```