### PR TITLE
Support for #-style comments

### DIFF
--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -193,9 +193,6 @@ func (s *Scanner) Scan() (
 				tok = s.switch2(token.Quo, token.QuoAssign)
 			}
 		case '#':
-			if s.ch != '!' {
-				s.ch = '!'
-			}
 			comment := s.scanComment()
 			if s.mode&ScanComments == 0 {
 				// skip comment
@@ -309,8 +306,7 @@ func (s *Scanner) scanComment() string {
 	}
 
 	// #! shebang & #-style comment support
-	if s.ch == '!' {
-		s.next()
+	if s.src[offs] == '#' {
 		for s.ch != '\n' && s.ch >= 0 {
 			if s.ch == '\r' {
 				numCR++

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -32,6 +32,14 @@ func TestScanner_Scan(t *testing.T) {
 		{token.Comment, "/**\r/*/"},
 		{token.Comment, "/**\r\r/*/"},
 		{token.Comment, "//\r\n"},
+		{token.Comment, "#\n"},
+		{token.Comment, "#\r\n"},
+		{token.Comment, "#!\n"},
+		{token.Comment, "#!\r\n"},
+		{token.Comment, "# a comment\n"},
+		{token.Comment, "# a comment\r\n"},
+		{token.Comment, "#a comment\n"},
+		{token.Comment, "#a comment\r\n"},
 		{token.Ident, "foobar"},
 		{token.Ident, "a۰۱۸"},
 		{token.Ident, "foo६४"},
@@ -155,7 +163,7 @@ func TestScanner_Scan(t *testing.T) {
 				tc.literal[1] == '*'))
 
 			//-style comment literal doesn't contain newline
-			if expectedLiteral[1] == '/' {
+			if expectedLiteral[0] == '#' || expectedLiteral[1] == '/' {
 				expectedLiteral = expectedLiteral[:len(expectedLiteral)-1]
 			}
 		case token.Ident:


### PR DESCRIPTION
This pull request allows to use #-style comments in tengo as well as shebang support.  Fixes #251 

Shebang:
```tengo
#!/usr/local/bin/tengo

fmt := import("fmt")
fmt.println("Hello World")
```

Outputs:
```
╰─$ ./test.tengo
Hello World
```