### PR TITLE
Fix nested file imports

### DIFF
--- a/cmd/tengo/main.go
+++ b/cmd/tengo/main.go
@@ -67,8 +67,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else if filepath.Ext(inputFile) == sourceFileExt {
-		if len(inputData) > 1 &&
-			bytes.Compare(inputData[:2], []byte("#!")) == 0 {
+		if len(inputData) > 1 && string(inputData[:2]) == "#!" {
 			copy(inputData, "//")
 		}
 		err := CompileAndRun(modules, inputData, inputFile)

--- a/compiler.go
+++ b/compiler.go
@@ -1086,6 +1086,8 @@ func (c *Compiler) fork(
 	child := NewCompiler(file, symbolTable, nil, c.modules, c.trace)
 	child.modulePath = modulePath // module file path
 	child.parent = c              // parent to set to current compiler
+	// Fixes #281 inherit file import from parent compiler
+	child.allowFileImport = c.allowFileImport
 	return child
 }
 

--- a/compiler.go
+++ b/compiler.go
@@ -1086,7 +1086,6 @@ func (c *Compiler) fork(
 	child := NewCompiler(file, symbolTable, nil, c.modules, c.trace)
 	child.modulePath = modulePath // module file path
 	child.parent = c              // parent to set to current compiler
-	// Fixes #281 inherit file import from parent compiler
 	child.allowFileImport = c.allowFileImport
 	return child
 }


### PR DESCRIPTION
Closes #281 by enabling child compiler to inherit file import allowance.
Also, a better way to compare bytes for shebang.