### PR TITLE
fix a compiler bug with dead code optimization

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -1192,6 +1192,7 @@ func (c *Compiler) optimizeFunc(node parser.Node) {
 	var lastOp parser.Opcode
 	var appendReturn bool
 	endPos := len(c.scopes[c.scopeIndex].Instructions)
+	newEndPost := len(newInsts)
 	iterateInstructions(newInsts,
 		func(pos int, opcode parser.Opcode, operands []int) bool {
 			switch opcode {
@@ -1204,6 +1205,8 @@ func (c *Compiler) optimizeFunc(node parser.Node) {
 				} else if endPos == operands[0] {
 					// there's a jump instruction that jumps to the end of
 					// function compiler should append "return".
+					copy(newInsts[pos:],
+						MakeInstruction(opcode, newEndPost))
 					appendReturn = true
 				} else {
 					panic(fmt.Errorf("invalid jump position: %d", newDst))


### PR DESCRIPTION
There was a bug in the dead code elimination in Compiler: operands for the jump instructions that jump to the end of the function should be updated properly.

Fixes #283 