### PR TITLE
Spread last call argument

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -497,6 +497,14 @@ func (c *Compiler) Compile(node parser.Node) error {
 			}
 			c.emit(node, parser.OpReturn, 1)
 		}
+	case *parser.SpreadExpr:
+		if node.Expr == nil {
+			return c.errorf(node, "spread expression is nil")
+		}
+		if err := c.Compile(node.Expr); err != nil {
+			return err
+		}
+		c.emit(node, parser.OpSpread)
 	case *parser.CallExpr:
 		if err := c.Compile(node.Func); err != nil {
 			return err

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -483,6 +483,26 @@ func TestCompiler_Compile(t *testing.T) {
 				intObject(3),
 				intObject(0))))
 
+	expectCompile(t, `f1 := func(a) { return a }; f1(...[1, 2]);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpArray, 2),
+				tengo.MakeInstruction(parser.OpSpread),
+				tengo.MakeInstruction(parser.OpCall, 1),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				intObject(1),
+				intObject(2))))
+
 	expectCompile(t, `func() { return 5 + 10 }`,
 		bytecode(
 			concatInsts(

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -483,7 +483,7 @@ func TestCompiler_Compile(t *testing.T) {
 				intObject(3),
 				intObject(0))))
 
-	expectCompile(t, `f1 := func(a) { return a }; f1(...[1, 2]);`,
+	expectCompile(t, `f1 := func(a) { return a }; f1([1, 2]...);`,
 		bytecode(
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 0),

--- a/objects.go
+++ b/objects.go
@@ -1611,3 +1611,23 @@ func (o *UserFunction) Call(args ...Object) (Object, error) {
 func (o *UserFunction) CanCall() bool {
 	return true
 }
+
+// Spreader is an interface to let user defined (custom) types to use spread
+// expression in function calls.
+type Spreader interface {
+	Spread() (Object, error)
+}
+
+// spreadType is used internally by VM.
+type spreadType struct {
+	ObjectImpl
+}
+
+// TypeName returns the name of the type.
+func (*spreadType) TypeName() string {
+	return "spread"
+}
+
+func (*spreadType) String() string {
+	return "<spread>"
+}

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -595,3 +595,28 @@ func (e *UndefinedLit) End() Pos {
 func (e *UndefinedLit) String() string {
 	return "undefined"
 }
+
+// SpreadExpr node stands for the "..." spread expression.
+type SpreadExpr struct {
+	TokenPos Pos // position of "..."
+	Expr     Expr
+}
+
+func (e *SpreadExpr) exprNode() {}
+
+// Pos returns the position of first character belonging to the node.
+func (e *SpreadExpr) Pos() Pos {
+	return e.TokenPos
+}
+
+// End returns the position of first character immediately after the node.
+func (e *SpreadExpr) End() Pos {
+	return e.TokenPos + 3 + e.Expr.End()
+}
+
+func (e *SpreadExpr) String() string {
+	if e.Expr == nil {
+		return "..."
+	}
+	return e.Expr.String() + "..."
+}

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -611,7 +611,7 @@ func (e *SpreadExpr) Pos() Pos {
 
 // End returns the position of first character immediately after the node.
 func (e *SpreadExpr) End() Pos {
-	return e.TokenPos + 3 + e.Expr.End()
+	return e.TokenPos + 3
 }
 
 func (e *SpreadExpr) String() string {

--- a/parser/opcodes.go
+++ b/parser/opcodes.go
@@ -47,6 +47,7 @@ const (
 	OpIteratorValue               // Iterator value
 	OpBinaryOp                    // Binary operation
 	OpSuspend                     // Suspend VM
+	OpSpread                      // Spread call arg, map and array items
 )
 
 // OpcodeNames are string representation of opcodes.
@@ -93,6 +94,7 @@ var OpcodeNames = [...]string{
 	OpIteratorValue: "ITVAL",
 	OpBinaryOp:      "BINARYOP",
 	OpSuspend:       "SUSPEND",
+	OpSpread:        "SPREAD",
 }
 
 // OpcodeOperands is the number of operands.
@@ -139,6 +141,7 @@ var OpcodeOperands = [...][]int{
 	OpIteratorValue: {},
 	OpBinaryOp:      {1},
 	OpSuspend:       {},
+	OpSpread:        {},
 }
 
 // ReadOperands reads operands from the bytecode.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -272,17 +272,17 @@ func (p *Parser) parseCall(x Expr) *CallExpr {
 	var list []Expr
 	var ellipsis Pos
 	for p.token != token.RParen && p.token != token.EOF && !ellipsis.IsValid() {
+		expr := p.parseExpr()
 		if p.token == token.Ellipsis {
 			ellipsis = p.pos
 			p.next()
-			expr := p.parseExpr()
 			spread := &SpreadExpr{
 				TokenPos: ellipsis,
 				Expr:     expr,
 			}
 			list = append(list, spread)
 		} else {
-			list = append(list, p.parseExpr())
+			list = append(list, expr)
 		}
 		if !p.expectComma(token.RParen, "call argument") {
 			break

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -270,9 +270,20 @@ func (p *Parser) parseCall(x Expr) *CallExpr {
 	p.exprLevel++
 
 	var list []Expr
-	for p.token != token.RParen && p.token != token.EOF {
-		list = append(list, p.parseExpr())
-
+	var ellipsis Pos
+	for p.token != token.RParen && p.token != token.EOF && !ellipsis.IsValid() {
+		if p.token == token.Ellipsis {
+			ellipsis = p.pos
+			p.next()
+			expr := p.parseExpr()
+			spread := &SpreadExpr{
+				TokenPos: ellipsis,
+				Expr:     expr,
+			}
+			list = append(list, spread)
+		} else {
+			list = append(list, p.parseExpr())
+		}
 		if !p.expectComma(token.RParen, "call argument") {
 			break
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -296,7 +296,7 @@ func TestParseCall(t *testing.T) {
 					intLit(3, p(1, 11)))))
 	})
 
-	expectParse(t, "add(1, 2, ...v)", func(p pfn) []Stmt {
+	expectParse(t, "add(1, 2, v...)", func(p pfn) []Stmt {
 		return stmts(
 			exprStmt(
 				callExpr(
@@ -304,8 +304,8 @@ func TestParseCall(t *testing.T) {
 					p(1, 4), p(1, 15),
 					intLit(1, p(1, 5)),
 					intLit(2, p(1, 8)),
-					spreadExpr(p(1, 11),
-						ident("v", p(1, 14)),
+					spreadExpr(p(1, 12),
+						ident("v", p(1, 11)),
 					))))
 	})
 
@@ -435,12 +435,13 @@ func TestParseCall(t *testing.T) {
 	})
 
 	expectParseError(t, `add(...a, 1)`)
-	expectParseError(t, `add(...a, ...b)`)
-	expectParseError(t, `add(1, ...a, ...b)`)
+	expectParseError(t, `add(a..., 1)`)
+	expectParseError(t, `add(a..., b...)`)
+	expectParseError(t, `add(1, a..., b...)`)
 	expectParseError(t, `add(...)`)
 	expectParseError(t, `add(1, ...)`)
 	expectParseError(t, `add(1, ..., )`)
-	expectParseError(t, `add(a...)`)
+	expectParseError(t, `add(...a)`)
 }
 
 func TestParseChar(t *testing.T) {

--- a/vm_test.go
+++ b/vm_test.go
@@ -3477,50 +3477,50 @@ func TestSpread(t *testing.T) {
 	f := func(...a) {
 		return append(a, 3)
 	}
-	out = f(...[1, 2])
+	out = f([1, 2]...)
 	`, nil, ARR{1, 2, 3})
 
 	expectRun(t, `
 	f := func(a, ...b) {
-		return append([a], ...append(b, 3))
+		return append([a], append(b, 3)...)
 	}
-	out = f(...[1, 2])
+	out = f([1, 2]...)
 	`, nil, ARR{1, 2, 3})
 
 	expectRun(t, `
 	f := func(a, ...b) {
 		return append(append([a], b), 3)
 	}
-	out = f(1, ...[2])
+	out = f(1, [2]...)
 	`, nil, ARR{1, ARR{2}, 3})
 
 	expectRun(t, `
 	f1 := func(...a){
-		return append([3], ...a)
+		return append([3], a...)
 	}
 	f2 := func(a, ...b) {
-		return f1(...append([a], ...b))
+		return f1(append([a], b...)...)
 	}
-	out = f2(...[1, 2])
+	out = f2([1, 2]...)
 	`, nil, ARR{3, 1, 2})
 
 	expectRun(t, `
 	f := func(a, ...b) {
 		return func(...a) {
-			return append([3], ...append(a, 4))
-		}(a, ...b)
+			return append([3], append(a, 4)...)
+		}(a, b...)
 	}
-	out = f(...[1, 2])
+	out = f([1, 2]...)
 	`, nil, ARR{3, 1, 2, 4})
 
 	expectRun(t, `
 	f := func(a, ...b) {
 		c := append(b, 4)
 		return func(){
-			return append(append([a], ...b), ...c)
+			return append(append([a], b...), c...)
 		}()
 	}
-	out = f(1, ...immutable([2, 3]))
+	out = f(1, immutable([2, 3])...)
 	`, nil, ARR{1, 2, 3, 2, 3, 4})
 
 	// spread custom types
@@ -3529,13 +3529,13 @@ func TestSpread(t *testing.T) {
 	f := func(...a) {
 		return append(a, "c")
 	}
-	out = f(...input)`,
+	out = f(input...)`,
 		Opts().Symbol("input", custom).Skip2ndPass(),
 		ARR{"a", "b", "c"})
 
-	expectError(t, `func(a) {}(...[1, 2])`, nil,
+	expectError(t, `func(a) {}([1, 2]...)`, nil,
 		"Runtime Error: wrong number of arguments: want=1, got=2")
-	expectError(t, `func(a, b, c) {}(...[1, 2])`, nil,
+	expectError(t, `func(a, b, c) {}([1, 2]...)`, nil,
 		"Runtime Error: wrong number of arguments: want=3, got=2")
 }
 


### PR DESCRIPTION
- After feedback from #297 (spread in arrays, maps, call args), I removed spread for array and map, only last call argument can be spread.
- Ellipsis must come after the argument, not before (like Go).
- Only last argument can be spread (like Go).
- Call Args and function params match is not mandatory, `OpCall` takes whatever in the stack after spread and use it as before, no major `OpCall` changes.
- Docs are missing, will be added after PR approval.
- Cost of this is not calculated in terms of performance. Simple  benchmarks #265 show +~1% delta.
- Major version change is not required.
- This is a draft PR.