### PR TITLE
spread last call argument v2

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -506,7 +506,11 @@ func (c *Compiler) Compile(node parser.Node) error {
 				return err
 			}
 		}
-		c.emit(node, parser.OpCall, len(node.Args))
+		ellipsis := 0
+		if node.Ellipsis.IsValid() {
+			ellipsis = 1
+		}
+		c.emit(node, parser.OpCall, len(node.Args), ellipsis)
 	case *parser.ImportExpr:
 		if node.ModuleName == "" {
 			return c.errorf(node, "empty module name")
@@ -526,7 +530,7 @@ func (c *Compiler) Compile(node parser.Node) error {
 					return err
 				}
 				c.emit(node, parser.OpConstant, c.addConstant(compiled))
-				c.emit(node, parser.OpCall, 0)
+				c.emit(node, parser.OpCall, 0, 0)
 			case Object: // builtin module
 				c.emit(node, parser.OpConstant, c.addConstant(v))
 			default:
@@ -556,7 +560,7 @@ func (c *Compiler) Compile(node parser.Node) error {
 				return err
 			}
 			c.emit(node, parser.OpConstant, c.addConstant(compiled))
-			c.emit(node, parser.OpCall, 0)
+			c.emit(node, parser.OpCall, 0, 0)
 		} else {
 			return c.errorf(node, "module '%s' not found", node.ModuleName)
 		}

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -483,6 +483,25 @@ func TestCompiler_Compile(t *testing.T) {
 				intObject(3),
 				intObject(0))))
 
+	expectCompile(t, `f1 := func(a) { return a }; f1([1, 2]...);`,
+		bytecode(
+			concatInsts(
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpSetGlobal, 0),
+				tengo.MakeInstruction(parser.OpGetGlobal, 0),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpConstant, 2),
+				tengo.MakeInstruction(parser.OpArray, 2),
+				tengo.MakeInstruction(parser.OpCall, 1, 1),
+				tengo.MakeInstruction(parser.OpPop),
+				tengo.MakeInstruction(parser.OpSuspend)),
+			objectsArray(
+				compiledFunction(1, 1,
+					tengo.MakeInstruction(parser.OpGetLocal, 0),
+					tengo.MakeInstruction(parser.OpReturn, 1)),
+				intObject(1),
+				intObject(2))))
+
 	expectCompile(t, `func() { return 5 + 10 }`,
 		bytecode(
 			concatInsts(
@@ -601,7 +620,7 @@ func TestCompiler_Compile(t *testing.T) {
 		bytecode(
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpCall, 0),
+				tengo.MakeInstruction(parser.OpCall, 0, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -615,7 +634,7 @@ func TestCompiler_Compile(t *testing.T) {
 		bytecode(
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpCall, 0),
+				tengo.MakeInstruction(parser.OpCall, 0, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -630,7 +649,7 @@ func TestCompiler_Compile(t *testing.T) {
 				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpSetGlobal, 0),
 				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpCall, 0),
+				tengo.MakeInstruction(parser.OpCall, 0, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -646,7 +665,7 @@ func TestCompiler_Compile(t *testing.T) {
 				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpSetGlobal, 0),
 				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpCall, 0),
+				tengo.MakeInstruction(parser.OpCall, 0, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -710,7 +729,7 @@ func TestCompiler_Compile(t *testing.T) {
 				tengo.MakeInstruction(parser.OpSetGlobal, 0),
 				tengo.MakeInstruction(parser.OpGetGlobal, 0),
 				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpCall, 1),
+				tengo.MakeInstruction(parser.OpCall, 1, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -728,7 +747,7 @@ func TestCompiler_Compile(t *testing.T) {
 				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpConstant, 2),
 				tengo.MakeInstruction(parser.OpConstant, 3),
-				tengo.MakeInstruction(parser.OpCall, 3),
+				tengo.MakeInstruction(parser.OpCall, 3, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -746,7 +765,7 @@ func TestCompiler_Compile(t *testing.T) {
 				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpConstant, 2),
 				tengo.MakeInstruction(parser.OpConstant, 3),
-				tengo.MakeInstruction(parser.OpCall, 3),
+				tengo.MakeInstruction(parser.OpCall, 3, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
@@ -782,7 +801,7 @@ func TestCompiler_Compile(t *testing.T) {
 			concatInsts(
 				tengo.MakeInstruction(parser.OpGetBuiltin, 0),
 				tengo.MakeInstruction(parser.OpArray, 0),
-				tengo.MakeInstruction(parser.OpCall, 1),
+				tengo.MakeInstruction(parser.OpCall, 1, 0),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray()))
@@ -797,7 +816,7 @@ func TestCompiler_Compile(t *testing.T) {
 				compiledFunction(0, 0,
 					tengo.MakeInstruction(parser.OpGetBuiltin, 0),
 					tengo.MakeInstruction(parser.OpArray, 0),
-					tengo.MakeInstruction(parser.OpCall, 1),
+					tengo.MakeInstruction(parser.OpCall, 1, 0),
 					tengo.MakeInstruction(parser.OpReturn, 1)))))
 
 	expectCompile(t, `func(a) { func(b) { return a + b } }`,

--- a/docs/tengo-cli.md
+++ b/docs/tengo-cli.md
@@ -52,6 +52,12 @@ chmod +x myapp.tengo
 
 **Note: Your source file must have `.tengo` extension.**
 
+## Resolving Relative Import Paths
+
+If there are tengo source module files which are imported with relative import
+paths, CLI has `-resolve` flag. Flag enables to import a module relative to
+importing file. This behavior will be default at version 3.
+
 ## Tengo REPL
 
 You can run Tengo [REPL](https://en.wikipedia.org/wiki/Read–eval–print_loop)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -194,64 +194,28 @@ Only the last parameter can be variadic. The following code is also illegal:
 illegal := func(a..., b) { /*... */ }
 ```
 
-### Function Calls
-
-Function calls are strict for non-variadic function calls in terms of number of
-arguments provided. Provide exact number of arguments to non-variadic
-functions. But, callable objects, user functions created in Go and provided to
-Tengo scripts are variadic in nature so user must return appropriate error
-messages to caller about number and types of arguments if they are not as
-expected.
-
-In function calls, ellipsis `...` can be used to denote an literal/variable
-argument will be spread/unpacked/expanded (these words can be used
-interchangeably throughout the documentation). `Array` and `ImmutableArray`
-objects can be in front of the ellipsis if and only if it is last argument in
-function calls, similar to Go. Unlike Go, arrays can be spread onto non-variadic
-functions as well. See examples below;
+When calling a function, the number of passing arguments must match that of
+function definition.
 
 ```golang
 f := func(a, b) {}
-
 f(1, 2, 3) // Runtime Error: wrong number of arguments: want=2, got=3
 ```
 
-```golang
-f := func(a, ...b) {
-    // a == 1
-    // b == [2, 3]
-}
-f(1, [2, 3]...)
-```
+Like Go, you can use ellipsis `...` to pass array-type value as its last parameter:
 
 ```golang
-f := func(a, b) {
-    // a == 1
-    // b == 2
-}
-array := immutable([1, 2])
-f(array...)
-```
+f1 := func(a, b, c) { return a + b + c }
+f1([1, 2, 3]...)    // => 6
+f1(1, [2, 3]...)    // => 6
+f1(1, 2, [3]...)    // => 6
+f1([1, 2]...)       // Runtime Error: wrong number of arguments: want=3, got=2
 
-```golang
-f := func(a, b) {}
-
-array := [1, 2, 3]
-f(array...) // Runtime Error: wrong number of arguments: want=2, got=3
-```
-
-```golang
-f := func(a, b, ...c) {
-    // a == 1
-    // b == 2
-    // c == [3, 4]
-}
-f(1, [2, 3, 4]...)
-```
-
-```golang
-array := append([1], [2, 3]...)
-// array == [1, 2, 3]
+f2 := func(a, ...b) {}
+f2(1)               // valid; a = 1, b = []
+f2(1, 2)            // valid; a = 1, b = [2]
+f2(1, 2, 3)         // valid; a = 1, b = [2, 3]
+f2([1, 2, 3]...)    // valid; a = 1, b = [2, 3]
 ```
 
 ## Variables and Scopes
@@ -442,8 +406,7 @@ d := "hello world"[2:10]     // == "llo worl"
 c := [1, 2, 3, 4, 5][-1:10]  // == [1, 2, 3, 4, 5]
 ```
 
-**Note: Keywords `break, continue, else, for, func, error, immutable, if,
-return, export, true, false, in, undefined, import` cannot be used as selectors.**
+**Note: Keywords cannot be used as selectors.**
 
 ```golang
 a := {in: true} // Parse Error: expected map key, found 'in'

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -194,6 +194,66 @@ Only the last parameter can be variadic. The following code is also illegal:
 illegal := func(a..., b) { /*... */ }
 ```
 
+### Function Calls
+
+Function calls are strict for non-variadic function calls in terms of number of
+arguments provided. Provide exact number of arguments to non-variadic
+functions. But, callable objects, user functions created in Go and provided to
+Tengo scripts are variadic in nature so user must return appropriate error
+messages to caller about number and types of arguments if they are not as
+expected.
+
+In function calls, ellipsis `...` can be used to denote an literal/variable
+argument will be spread/unpacked/expanded (these words can be used
+interchangeably throughout the documentation). `Array` and `ImmutableArray`
+objects can be in front of the ellipsis if and only if it is last argument in
+function calls, similar to Go. Unlike Go, arrays can be spread onto non-variadic
+functions as well. See examples below;
+
+```golang
+f := func(a, b) {}
+
+f(1, 2, 3) // Runtime Error: wrong number of arguments: want=2, got=3
+```
+
+```golang
+f := func(a, ...b) {
+    // a == 1
+    // b == [2, 3]
+}
+f(1, [2, 3]...)
+```
+
+```golang
+f := func(a, b) {
+    // a == 1
+    // b == 2
+}
+array := immutable([1, 2])
+f(array...)
+```
+
+```golang
+f := func(a, b) {}
+
+array := [1, 2, 3]
+f(array...) // Runtime Error: wrong number of arguments: want=2, got=3
+```
+
+```golang
+f := func(a, b, ...c) {
+    // a == 1
+    // b == 2
+    // c == [3, 4]
+}
+f(1, [2, 3, 4]...)
+```
+
+```golang
+array := append([1], [2, 3]...)
+// array == [1, 2, 3]
+```
+
 ## Variables and Scopes
 
 A value can be assigned to a variable using assignment operator `:=` and `=`.
@@ -380,6 +440,21 @@ b := [1, 2, 3, 4, 5][3:]     // == [4, 5]
 c := [1, 2, 3, 4, 5][:3]     // == [1, 2, 3]
 d := "hello world"[2:10]     // == "llo worl"
 c := [1, 2, 3, 4, 5][-1:10]  // == [1, 2, 3, 4, 5]
+```
+
+**Note: Keywords `break, continue, else, for, func, error, immutable, if,
+return, export, true, false, in, undefined, import` cannot be used as selectors.**
+
+```golang
+a := {in: true} // Parse Error: expected map key, found 'in'
+a.func = ""     // Parse Error: expected selector, found 'func'
+```
+
+Use double quotes and indexer to use keywords with maps.
+
+```golang
+a := {"in": true}
+a["func"] = ""
 ```
 
 ## Statements

--- a/objects.go
+++ b/objects.go
@@ -1611,3 +1611,9 @@ func (o *UserFunction) Call(args ...Object) (Object, error) {
 func (o *UserFunction) CanCall() bool {
 	return true
 }
+
+// Spreader is an interface to let user defined (custom) types to use spread
+// expression in function calls.
+type Spreader interface {
+	Spread() (Object, error)
+}

--- a/objects.go
+++ b/objects.go
@@ -1611,9 +1611,3 @@ func (o *UserFunction) Call(args ...Object) (Object, error) {
 func (o *UserFunction) CanCall() bool {
 	return true
 }
-
-// Spreader is an interface to let user defined (custom) types to use spread
-// expression in function calls.
-type Spreader interface {
-	Spread() (Object, error)
-}

--- a/parser/expr.go
+++ b/parser/expr.go
@@ -111,10 +111,11 @@ func (e *BoolLit) String() string {
 
 // CallExpr represents a function call expression.
 type CallExpr struct {
-	Func   Expr
-	LParen Pos
-	Args   []Expr
-	RParen Pos
+	Func     Expr
+	LParen   Pos
+	Args     []Expr
+	Ellipsis Pos
+	RParen   Pos
 }
 
 func (e *CallExpr) exprNode() {}
@@ -133,6 +134,9 @@ func (e *CallExpr) String() string {
 	var args []string
 	for _, e := range e.Args {
 		args = append(args, e.String())
+	}
+	if len(args) > 0 && e.Ellipsis.IsValid() {
+		args[len(args)-1] = args[len(args)-1] + "..."
 	}
 	return e.Func.String() + "(" + strings.Join(args, ", ") + ")"
 }

--- a/parser/opcodes.go
+++ b/parser/opcodes.go
@@ -120,7 +120,7 @@ var OpcodeOperands = [...][]int{
 	OpImmutable:     {},
 	OpIndex:         {},
 	OpSliceIndex:    {},
-	OpCall:          {1},
+	OpCall:          {1, 1},
 	OpReturn:        {1},
 	OpGetLocal:      {1},
 	OpSetLocal:      {1},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -270,9 +270,13 @@ func (p *Parser) parseCall(x Expr) *CallExpr {
 	p.exprLevel++
 
 	var list []Expr
-	for p.token != token.RParen && p.token != token.EOF {
+	var ellipsis Pos
+	for p.token != token.RParen && p.token != token.EOF && !ellipsis.IsValid() {
 		list = append(list, p.parseExpr())
-
+		if p.token == token.Ellipsis {
+			ellipsis = p.pos
+			p.next()
+		}
 		if !p.expectComma(token.RParen, "call argument") {
 			break
 		}
@@ -281,10 +285,11 @@ func (p *Parser) parseCall(x Expr) *CallExpr {
 	p.exprLevel--
 	rparen := p.expect(token.RParen)
 	return &CallExpr{
-		Func:   x,
-		LParen: lparen,
-		RParen: rparen,
-		Args:   list,
+		Func:     x,
+		LParen:   lparen,
+		RParen:   rparen,
+		Ellipsis: ellipsis,
+		Args:     list,
 	}
 }
 

--- a/vm.go
+++ b/vm.go
@@ -537,12 +537,59 @@ func (v *VM) run() {
 			}
 		case parser.OpCall:
 			numArgs := int(v.curInsts[v.ip+1])
-			v.ip++
+			spread := int(v.curInsts[v.ip+2])
+			v.ip += 2
+
 			value := v.stack[v.sp-1-numArgs]
 			if !value.CanCall() {
 				v.err = fmt.Errorf("not callable: %s", value.TypeName())
 				return
 			}
+
+			if spread == 1 {
+				v.sp--
+				switch arr := v.stack[v.sp].(type) {
+				case *Array:
+					for _, item := range arr.Value {
+						v.stack[v.sp] = item
+						v.sp++
+					}
+					numArgs += len(arr.Value) - 1
+				case *ImmutableArray:
+					for _, item := range arr.Value {
+						v.stack[v.sp] = item
+						v.sp++
+					}
+					numArgs += len(arr.Value) - 1
+				case Spreader:
+					o, err := arr.Spread()
+					if err != nil {
+						v.err = err
+						return
+					}
+					switch arr := o.(type) {
+					case *Array:
+						for _, item := range arr.Value {
+							v.stack[v.sp] = item
+							v.sp++
+						}
+						numArgs += len(arr.Value) - 1
+					case *ImmutableArray:
+						for _, item := range arr.Value {
+							v.stack[v.sp] = item
+							v.sp++
+						}
+						numArgs += len(arr.Value) - 1
+					default:
+						v.err = fmt.Errorf("not an array: %s", arr.TypeName())
+						return
+					}
+				default:
+					v.err = fmt.Errorf("not an array: %s", arr.TypeName())
+					return
+				}
+			}
+
 			if callee, ok := value.(*CompiledFunction); ok {
 				if callee.VarArgs {
 					// if the closure is variadic,

--- a/vm.go
+++ b/vm.go
@@ -561,29 +561,6 @@ func (v *VM) run() {
 						v.sp++
 					}
 					numArgs += len(arr.Value) - 1
-				case Spreader:
-					o, err := arr.Spread()
-					if err != nil {
-						v.err = err
-						return
-					}
-					switch arr := o.(type) {
-					case *Array:
-						for _, item := range arr.Value {
-							v.stack[v.sp] = item
-							v.sp++
-						}
-						numArgs += len(arr.Value) - 1
-					case *ImmutableArray:
-						for _, item := range arr.Value {
-							v.stack[v.sp] = item
-							v.sp++
-						}
-						numArgs += len(arr.Value) - 1
-					default:
-						v.err = fmt.Errorf("not an array: %s", arr.TypeName())
-						return
-					}
 				default:
 					v.err = fmt.Errorf("not an array: %s", arr.TypeName())
 					return

--- a/vm_test.go
+++ b/vm_test.go
@@ -3472,6 +3472,73 @@ func() {
 }()`, nil, 25)
 }
 
+func TestSpread(t *testing.T) {
+	expectRun(t, `
+	f := func(...a) {
+		return append(a, 3)
+	}
+	out = f([1, 2]...)
+	`, nil, ARR{1, 2, 3})
+
+	expectRun(t, `
+	f := func(a, ...b) {
+		return append([a], append(b, 3)...)
+	}
+	out = f([1, 2]...)
+	`, nil, ARR{1, 2, 3})
+
+	expectRun(t, `
+	f := func(a, ...b) {
+		return append(append([a], b), 3)
+	}
+	out = f(1, [2]...)
+	`, nil, ARR{1, ARR{2}, 3})
+
+	expectRun(t, `
+	f1 := func(...a){
+		return append([3], a...)
+	}
+	f2 := func(a, ...b) {
+		return f1(append([a], b...)...)
+	}
+	out = f2([1, 2]...)
+	`, nil, ARR{3, 1, 2})
+
+	expectRun(t, `
+	f := func(a, ...b) {
+		return func(...a) {
+			return append([3], append(a, 4)...)
+		}(a, b...)
+	}
+	out = f([1, 2]...)
+	`, nil, ARR{3, 1, 2, 4})
+
+	expectRun(t, `
+	f := func(a, ...b) {
+		c := append(b, 4)
+		return func(){
+			return append(append([a], b...), c...)
+		}()
+	}
+	out = f(1, immutable([2, 3])...)
+	`, nil, ARR{1, 2, 3, 2, 3, 4})
+
+	// spread custom types
+	custom := &SpreadMock{Object: toObject(ARR{"a", "b"})}
+	expectRun(t, `
+	f := func(...a) {
+		return append(a, "c")
+	}
+	out = f(input...)`,
+		Opts().Symbol("input", custom).Skip2ndPass(),
+		ARR{"a", "b", "c"})
+
+	expectError(t, `func(a) {}([1, 2]...)`, nil,
+		"Runtime Error: wrong number of arguments: want=1, got=2")
+	expectError(t, `func(a, b, c) {}([1, 2]...)`, nil,
+		"Runtime Error: wrong number of arguments: want=3, got=2")
+}
+
 func expectRun(
 	t *testing.T,
 	input string,
@@ -3826,4 +3893,25 @@ func objectZeroCopy(o tengo.Object) tengo.Object {
 	default:
 		panic(fmt.Errorf("unknown object type: %s", o.TypeName()))
 	}
+}
+
+type SpreadMock struct {
+	tengo.ObjectImpl
+	Object tengo.Object
+	Error  error
+}
+
+func (m *SpreadMock) Spread() (tengo.Object, error) {
+	if m.Error == nil {
+		return m.Object, nil
+	}
+	return nil, m.Error
+}
+
+func (m *SpreadMock) TypeName() string {
+	return "SpreadMock"
+}
+
+func (m *SpreadMock) String() string {
+	return "<SpreadMock>"
 }

--- a/vm_test.go
+++ b/vm_test.go
@@ -3523,16 +3523,6 @@ func TestSpread(t *testing.T) {
 	out = f(1, immutable([2, 3])...)
 	`, nil, ARR{1, 2, 3, 2, 3, 4})
 
-	// spread custom types
-	custom := &SpreadMock{Object: toObject(ARR{"a", "b"})}
-	expectRun(t, `
-	f := func(...a) {
-		return append(a, "c")
-	}
-	out = f(input...)`,
-		Opts().Symbol("input", custom).Skip2ndPass(),
-		ARR{"a", "b", "c"})
-
 	expectError(t, `func(a) {}([1, 2]...)`, nil,
 		"Runtime Error: wrong number of arguments: want=1, got=2")
 	expectError(t, `func(a, b, c) {}([1, 2]...)`, nil,
@@ -3893,25 +3883,4 @@ func objectZeroCopy(o tengo.Object) tengo.Object {
 	default:
 		panic(fmt.Errorf("unknown object type: %s", o.TypeName()))
 	}
-}
-
-type SpreadMock struct {
-	tengo.ObjectImpl
-	Object tengo.Object
-	Error  error
-}
-
-func (m *SpreadMock) Spread() (tengo.Object, error) {
-	if m.Error == nil {
-		return m.Object, nil
-	}
-	return nil, m.Error
-}
-
-func (m *SpreadMock) TypeName() string {
-	return "SpreadMock"
-}
-
-func (m *SpreadMock) String() string {
-	return "<SpreadMock>"
 }


### PR DESCRIPTION
This PR is created in favor of feedback in #299 
- No new OpCode is introduced.
- OpCall has two operands now. Existing compiled scripts do not work, recompilation is required.
- OpCall second operand is used to denote whether last stack object is expanded/spread or not, which must be valid tengo Object `*Array, *ImmutableArray` or for custom user types `Spreader`.
