### PR TITLE
For the OpMap VM instruction, since numElements is known just use the capacity hint.

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -293,7 +293,7 @@ func (v *VM) run() {
 		case parser.OpMap:
 			v.ip += 2
 			numElements := int(v.curInsts[v.ip]) | int(v.curInsts[v.ip-1])<<8
-			kv := make(map[string]Object)
+			kv := make(map[string]Object, numElements)
 			for i := v.sp - numElements; i < v.sp; i += 2 {
 				key := v.stack[i]
 				value := v.stack[i+1]


### PR DESCRIPTION
This optimization perhaps is premature but I think it's a small easy win to just allocate the map precisely with the target number of elements since they are known from the bytecode operand.