### PR TITLE
add custom extension support for importing source file

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -644,19 +644,15 @@ func (c *Compiler) SetImportDir(dir string) {
 // local module files.
 //
 // Use this method if you want other source file extension than ".tengo".
-// Note that this will replace the current list of extension name.
 //
 //     // this will search for *.tengo, *.foo, *.bar
 //     err := c.SetImportFileExt(".tengo", ".foo", ".bar")
 //
+// This function requires at least one argument, since it will replace the
+// current list of extension name.
 func (c *Compiler) SetImportFileExt(exts ...string) error {
-	if len(c.importFileExt) == 0 {
-		// At least one extension name is required.
-		c.importFileExt = []string{SourceFileExtDefault}
-	}
-
 	if len(exts) == 0 {
-		return nil // do nothing
+		return fmt.Errorf("missing arg: at least one argument is required")
 	}
 
 	for _, ext := range exts {

--- a/compiler.go
+++ b/compiler.go
@@ -640,10 +640,16 @@ func (c *Compiler) SetImportDir(dir string) {
 	c.importDir = dir
 }
 
-// SetImportExt sets the custom extension name of the source file for
+// SetImportFileExt sets the custom extension name of the source file for
 // loading local module files.
-func (c *Compiler) SetImportExt(ext string) {
+func (c *Compiler) SetImportFileExt(ext string) {
 	c.importExt = append(c.importExt, ext)
+}
+
+// GetImportFileExt returns a slice of custom extension name of the source
+// file for loading local module files.
+func (c *Compiler) GetImportFileExt() []string {
+	return c.importExt
 }
 
 func (c *Compiler) compileAssign(

--- a/compiler.go
+++ b/compiler.go
@@ -640,10 +640,34 @@ func (c *Compiler) SetImportDir(dir string) {
 	c.importDir = dir
 }
 
-// SetImportFileExt sets the custom extension name of the source file for
-// loading local module files.
-func (c *Compiler) SetImportFileExt(ext string) {
-	c.importExt = append(c.importExt, ext)
+// SetImportFileExt sets the extension name of the source file for loading
+// local module files.
+//
+// Use this method if you want other source file extension than ".tengo".
+// Note that this will replace the current list of extension name.
+//
+//     // this will search for *.tengo, *.foo, *.bar
+//     err := c.SetImportFileExt(".tengo", ".foo", ".bar")
+//
+func (c *Compiler) SetImportFileExt(exts ...string) error {
+	if len(c.importExt) == 0 {
+		// At least one extension name is required.
+		c.importExt = []string{SourceFileExtDefault}
+	}
+
+	if len(exts) == 0 {
+		return nil // do nothing
+	}
+
+	for _, ext := range exts {
+		if ext != filepath.Ext(ext) || ext == "" {
+			return fmt.Errorf("invalid file extension: %s", ext)
+		}
+	}
+
+	c.importExt = exts // Replace the hole current extension list
+
+	return nil
 }
 
 // GetImportFileExt returns a slice of custom extension name of the source

--- a/compiler.go
+++ b/compiler.go
@@ -47,7 +47,7 @@ type Compiler struct {
 	parent          *Compiler
 	modulePath      string
 	importDir       string
-	importExt       []string
+	importFileExt   []string
 	constants       []Object
 	symbolTable     *SymbolTable
 	scopes          []compilationScope
@@ -99,7 +99,7 @@ func NewCompiler(
 		trace:           trace,
 		modules:         modules,
 		compiledModules: make(map[string]*CompiledFunction),
-		importExt:       []string{SourceFileExtDefault},
+		importFileExt:   []string{SourceFileExtDefault},
 	}
 }
 
@@ -650,9 +650,9 @@ func (c *Compiler) SetImportDir(dir string) {
 //     err := c.SetImportFileExt(".tengo", ".foo", ".bar")
 //
 func (c *Compiler) SetImportFileExt(exts ...string) error {
-	if len(c.importExt) == 0 {
+	if len(c.importFileExt) == 0 {
 		// At least one extension name is required.
-		c.importExt = []string{SourceFileExtDefault}
+		c.importFileExt = []string{SourceFileExtDefault}
 	}
 
 	if len(exts) == 0 {
@@ -665,7 +665,7 @@ func (c *Compiler) SetImportFileExt(exts ...string) error {
 		}
 	}
 
-	c.importExt = exts // Replace the hole current extension list
+	c.importFileExt = exts // Replace the hole current extension list
 
 	return nil
 }
@@ -673,7 +673,7 @@ func (c *Compiler) SetImportFileExt(exts ...string) error {
 // GetImportFileExt returns a slice of custom extension name of the source
 // file for loading local module files.
 func (c *Compiler) GetImportFileExt() []string {
-	return c.importExt
+	return c.importFileExt
 }
 
 func (c *Compiler) compileAssign(
@@ -1134,7 +1134,7 @@ func (c *Compiler) fork(
 	child.parent = c              // parent to set to current compiler
 	child.allowFileImport = c.allowFileImport
 	child.importDir = c.importDir
-	child.importExt = c.importExt
+	child.importFileExt = c.importFileExt
 	if isFile && c.importDir != "" {
 		child.importDir = filepath.Dir(modulePath)
 	}
@@ -1325,7 +1325,7 @@ func (c *Compiler) printTrace(a ...interface{}) {
 }
 
 func (c *Compiler) getPathModule(moduleName string) (pathFile string, err error) {
-	for _, ext := range c.importExt {
+	for _, ext := range c.importFileExt {
 		nameFile := moduleName
 
 		if !strings.HasSuffix(nameFile, ext) {

--- a/compiler.go
+++ b/compiler.go
@@ -666,8 +666,9 @@ func (c *Compiler) SetImportFileExt(exts ...string) error {
 	return nil
 }
 
-// GetImportFileExt returns a slice of custom extension name of the source
-// file for loading local module files.
+// GetImportFileExt returns the current list of extension name.
+// Thease are the complementary suffix of the source file to search and load
+// local module files.
 func (c *Compiler) GetImportFileExt() []string {
 	return c.importFileExt
 }

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1226,7 +1226,7 @@ func() {
 }
 
 func TestCompiler_custom_extension(t *testing.T) {
-	pathFileSource := "./testdata/ext/test.mshk"
+	pathFileSource := "./testdata/issue286/test.mshk"
 
 	modules := stdlib.GetModuleMap(stdlib.AllModuleNames()...)
 

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1270,14 +1270,12 @@ func TestCompilerNewCompiler_default_file_extension(t *testing.T) {
 }
 
 func TestCompilerSetImportExt_extension_name_validation(t *testing.T) {
-	c := new(tengo.Compiler) // Instanciate a new compiler object with no initialization
+	c := new(tengo.Compiler) // Instantiate a new compiler object with no initialization
 
 	// Test of empty arg
 	err := c.SetImportFileExt()
 
-	require.NoError(t, err, "empty arg should not return error")
-	require.Equal(t, []string{".tengo"}, c.GetImportFileExt(),
-		"once the method was called but has no extension, the default should be set")
+	require.Error(t, err, "empty arg should return an error")
 
 	// Test of various arg types
 	for _, test := range []struct {
@@ -1286,6 +1284,8 @@ func TestCompilerSetImportExt_extension_name_validation(t *testing.T) {
 		requireErr bool
 		msgFail    string
 	}{
+		{[]string{".tengo"}, []string{".tengo"}, false,
+			"well-formed extension should not return an error"},
 		{[]string{""}, []string{".tengo"}, true,
 			"empty extension name should return an error"},
 		{[]string{"foo"}, []string{".tengo"}, true,

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1248,7 +1248,7 @@ func TestCompiler_custom_extension(t *testing.T) {
 	c := tengo.NewCompiler(srcFile, nil, nil, modules, nil)
 	c.EnableFileImport(true)
 	c.SetImportDir(filepath.Dir(pathFileSource))
-	c.SetImportExt(".mshk")
+	c.SetImportFileExt(".mshk")
 
 	err = c.Compile(file)
 	require.NoError(t, err)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -37,7 +37,7 @@ Here's a list of all available value types in Tengo.
 | map | value map with string keys _(mutable)_ | `map[string]interface{}` |
 | immutable map | [immutable](#immutable-values) map | - |
 | undefined | [undefined](#undefined-values) value | - |
-| function | [function](#function-values) value | - |  
+| function | [function](#function-values) value | - |
 | _user-defined_ | value of [user-defined types](https://github.com/d5/tengo/blob/master/docs/objects.md) | - |
 
 ### Error Values
@@ -45,14 +45,14 @@ Here's a list of all available value types in Tengo.
 In Tengo, an error can be represented using "error" typed values. An error
 value is created using `error` expression, and, it must have an underlying
 value. The underlying value of an error value can be access using `.value`
-selector.  
+selector.
 
 ```golang
 err1 := error("oops")    // error with string value
 err2 := error(1+2+3)     // error with int value
 if is_error(err1) {      // 'is_error' builtin function
   err_val := err1.value  // get underlying value
-}  
+}
 ```
 
 ### Immutable Values
@@ -101,12 +101,12 @@ a.c[1] = 5     // illegal
 ### Undefined Values
 
 In Tengo, an "undefined" value can be used to represent an unexpected or
-non-existing value:  
+non-existing value:
 
 - A function that does not return a value explicitly considered to return
 `undefined` value.
 - Indexer or selector on composite value types may return `undefined` if the
-key or index does not exist.  
+key or index does not exist.
 - Type conversion builtin functions without a default value will return
 `undefined` if conversion fails.
 
@@ -142,8 +142,8 @@ m["b"]                                // == false
 m.c                                   // == "foo"
 m.x                                   // == undefined
 
-{a: [1,2,3], b: {c: "foo", d: "bar"}} // ok: map with an array element and a map element  
-```  
+{a: [1,2,3], b: {c: "foo", d: "bar"}} // ok: map with an array element and a map element
+```
 
 ### Function Values
 
@@ -233,7 +233,7 @@ a := "foo"      // define 'a' in global scope
 
 func() {        // function scope A
   b := 52       // define 'b' in function scope A
-  
+
   func() {      // function scope B
     c := 19.84  // define 'c' in function scope B
 
@@ -243,12 +243,12 @@ func() {        // function scope A
     b := true   // ok: define new 'b' in function scope B
                 //     (shadowing 'b' from function scope A)
   }
-  
+
   a = "bar"     // ok: assigne new value to 'a' from global scope
   b = 10        // ok: assigne new value to 'b'
   a := -100     // ok: define new 'a' in function scope A
                 //     (shadowing 'a' from global scope)
-  
+
   c = -9.1      // illegal: 'c' is not defined
   b := [1, 2]   // illegal: 'b' is already defined in the same scope
 }
@@ -470,7 +470,7 @@ for {
 
 "For-In" statement is new in Tengo. It's similar to Go's `for range` statement.
 "For-In" statement can iterate any iterable value types (array, map, bytes,
-string, undefined).  
+string, undefined).
 
 ```golang
 for v in [1, 2, 3] {          // array: element
@@ -478,7 +478,7 @@ for v in [1, 2, 3] {          // array: element
 }
 for i, v in [1, 2, 3] {       // array: index and element
   // 'i' is index
-  // 'v' is value  
+  // 'v' is value
 }
 for k, v in {k1: 1, k2: 2} {  // map: key and value
   // 'k' is key
@@ -508,6 +508,16 @@ export func(x) {
 }
 ```
 
+By default, `import` solves the missing extension name of a module file as
+"`.tengo`"[^note].
+Thus, `sum := import("./sum")` is equivalent to `sum := import("./sum.tengo")`.
+
+[^note]:
+    If using Tengo as a library in Go, the file extension name "`.tengo`" can
+    be customized. In that case, use the `SetImportFileExt` function of the
+    `Compiler` type.
+    See the [Go reference](https://pkg.go.dev/github.com/d5/tengo/v2) for details.
+
 In Tengo, modules are very similar to functions.
 
 - `import` expression loads the module code and execute it like a function.
@@ -517,9 +527,9 @@ In Tengo, modules are very similar to functions.
   return a value to the importing code.
   - `export`-ed values are always immutable.
   - If the module does not have any `export` statement, `import` expression
-  simply returns `undefined`. _(Just like the function that has no `return`.)_  
+  simply returns `undefined`. _(Just like the function that has no `return`.)_
   - Note that `export` statement is completely ignored and not evaluated if
-  the code is executed as a main module.  
+  the code is executed as a main module.
 
 Also, you can use `import` expression to load the
 [Standard Library](https://github.com/d5/tengo/blob/master/docs/stdlib.md) as

--- a/tengo.go
+++ b/tengo.go
@@ -26,6 +26,9 @@ const (
 
 	// MaxFrames is the maximum number of function frames for a VM.
 	MaxFrames = 1024
+
+	// SourceFileExtDefault is the default extension for source files.
+	SourceFileExtDefault = ".tengo"
 )
 
 // CallableFunc is a function signature for the callable functions.

--- a/testdata/issue286/dos/cinco/cinco.mshk
+++ b/testdata/issue286/dos/cinco/cinco.mshk
@@ -1,0 +1,8 @@
+export {
+    fn: func(...args) {
+        text := import("text")
+        args = append(args, "cinco")
+
+        return text.join(args, " ")
+    }
+}

--- a/testdata/issue286/dos/dos.mshk
+++ b/testdata/issue286/dos/dos.mshk
@@ -1,0 +1,7 @@
+export {
+    fn: func(a, b) {
+        tres := import("../tres")
+
+        return tres.fn(a, b, "dos")
+    }
+}

--- a/testdata/issue286/dos/quatro/quatro.mshk
+++ b/testdata/issue286/dos/quatro/quatro.mshk
@@ -1,0 +1,7 @@
+export {
+    fn: func(a, b, c, d) {
+        cinco := import("../cinco/cinco")
+
+        return cinco.fn(a, b, c, d, "quatro")
+    }
+}

--- a/testdata/issue286/test.mshk
+++ b/testdata/issue286/test.mshk
@@ -1,7 +1,13 @@
 #!/usr/bin/env tengo
+// This is a test of custom extension for issue #286 and PR #350.
+// Which allows the tengo library to use custom extension names for the
+// source files.
+//
+// This test should pass if the interpreter's tengo.Compiler.SetImportExt()
+// was set as `c.SetImportExt(".tengo", ".mshk")`.
 
 os := import("os")
-uno := import("uno")
+uno := import("uno") // it will search uno.tengo and uno.mshk
 fmt := import("fmt")
 text := import("text")
 

--- a/testdata/issue286/test.mshk
+++ b/testdata/issue286/test.mshk
@@ -1,0 +1,17 @@
+#!/usr/bin/env tengo
+
+os := import("os")
+uno := import("uno")
+fmt := import("fmt")
+text := import("text")
+
+expected := ["test", "uno", "dos", "tres", "quatro", "cinco"]
+expected = text.join(expected, " ")
+if v := uno.fn("test"); v != expected {
+    fmt.printf("relative import test error:\n\texpected: %v\n\tgot     : %v\n",
+                expected, v)
+    os.exit(1)
+}
+
+args := text.join(os.args(), " ")
+fmt.println("ok\t", args)

--- a/testdata/issue286/tres.tengo
+++ b/testdata/issue286/tres.tengo
@@ -1,0 +1,6 @@
+export {
+    fn: func(a, b, c) {
+        quatro := import("./dos/quatro/quatro.mshk")
+        return quatro.fn(a, b, c, "tres")
+    }
+}

--- a/testdata/issue286/uno.mshk
+++ b/testdata/issue286/uno.mshk
@@ -1,0 +1,6 @@
+export {
+    fn: func(a) {
+        dos := import("dos/dos")
+        return dos.fn(a, "uno")
+    }
+}


### PR DESCRIPTION
This PR features issue #286 by implementing `tengo.Compiler.SetImportFileExt()` method which allows specifying custom extension names.

This feature aims for "`tengo`" as a library usage and should not affect the "/cmd/tengo" itself.

```diff
func main(){
...
	c := tengo.NewCompiler(srcFile, nil, nil, modules, nil)
	c.EnableFileImport(true)
	c.SetImportDir(filepath.Dir(pathFileSource))
+	err := c.SetImportFileExt(".tengo", ".mshk") // It will search *.tengo and *.mshk script files
...
}
```

- Related issue
  - #286
  - #332

---

- EDIT: Previously, in the first commit, `c.SetImportExt(".mshk")` searched for both `*.tengo` and `*.mshk` (`*.tengo` by default) with no input validation. <br>But currently it needs to explicitly define as `c.SetImportFileExt(".tengo", ".mshk")` for both file extensions. And returns an error if any given args are invalid as well.