### PR TITLE
fix deadcode optimization

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -1220,14 +1220,14 @@ func (c *Compiler) optimizeFunc(node parser.Node) {
 	iterateInstructions(c.scopes[c.scopeIndex].Instructions,
 		func(pos int, opcode parser.Opcode, operands []int) bool {
 			switch {
+			case dsts[pos]:
+				dstIdx++
+				deadCode = false
 			case opcode == parser.OpReturn:
 				if deadCode {
 					return true
 				}
 				deadCode = true
-			case dsts[pos]:
-				dstIdx++
-				deadCode = false
 			case deadCode:
 				return true
 			}
@@ -1242,6 +1242,7 @@ func (c *Compiler) optimizeFunc(node parser.Node) {
 	var appendReturn bool
 	endPos := len(c.scopes[c.scopeIndex].Instructions)
 	newEndPost := len(newInsts)
+
 	iterateInstructions(newInsts,
 		func(pos int, opcode parser.Opcode, operands []int) bool {
 			switch opcode {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1159,6 +1159,30 @@ func() {
 				tengo.MakeInstruction(parser.OpReturn, 1),
 				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpReturn, 1)))))
+
+	expectCompile(t, `
+func() {
+	if true {
+		return
+	}
+
+    return
+
+    return 123
+}`, bytecode(
+		concatInsts(
+			tengo.MakeInstruction(parser.OpConstant, 1),
+			tengo.MakeInstruction(parser.OpPop),
+			tengo.MakeInstruction(parser.OpSuspend)),
+		objectsArray(
+			intObject(123),
+			compiledFunction(0, 0,
+				tengo.MakeInstruction(parser.OpTrue),
+				tengo.MakeInstruction(parser.OpJumpFalsy, 6),
+				tengo.MakeInstruction(parser.OpReturn, 0),
+				tengo.MakeInstruction(parser.OpReturn, 0),
+				tengo.MakeInstruction(parser.OpConstant, 0),
+				tengo.MakeInstruction(parser.OpReturn, 1)))))
 }
 
 func TestCompilerScopes(t *testing.T) {


### PR DESCRIPTION
fixes #376

essentially we need to check and ignore the jump positions before we mark a return for elimination