### PR TITLE
update goreleaser to fix releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: 1.14
       - name: run goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
another one @d5. 

we have two options to fix releases, either increase compatibility to go 1.16+ or use newer goreleaser. more details here: https://github.com/goreleaser/goreleaser/pull/2069