### PR TITLE
Fix go releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
@d5 turns out the changes that fixed this got reverted in a later refactor. the most straightforward way to fix is to restrict to go 1.16+