### PR TITLE
fix runtime panics on self assignment

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -692,12 +692,15 @@ func (c *Compiler) compileAssign(
 		return c.errorf(node, "operator ':=' not allowed with selector")
 	}
 
+	_, isFunc := rhs[0].(*parser.FuncLit)
 	symbol, depth, exists := c.symbolTable.Resolve(ident, false)
 	if op == token.Define {
 		if depth == 0 && exists {
 			return c.errorf(node, "'%s' redeclared in this block", ident)
 		}
-		symbol = c.symbolTable.Define(ident)
+		if isFunc {
+			symbol = c.symbolTable.Define(ident)
+		}
 	} else {
 		if !exists {
 			return c.errorf(node, "unresolved reference '%s'", ident)
@@ -716,6 +719,10 @@ func (c *Compiler) compileAssign(
 		if err := c.Compile(expr); err != nil {
 			return err
 		}
+	}
+
+	if op == token.Define && !isFunc {
+		symbol = c.symbolTable.Define(ident)
 	}
 
 	switch op {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1023,6 +1023,8 @@ func TestCompilerErrorReport(t *testing.T) {
 
 	expectCompileError(t, `a = 1`,
 		"Compile Error: unresolved reference 'a'\n\tat test:1:1")
+	expectCompileError(t, `a := a`,
+		"Compile Error: unresolved reference 'a'\n\tat test:1:6")
 	expectCompileError(t, `a, b := 1, 2`,
 		"Compile Error: tuple assignment not allowed\n\tat test:1:1")
 	expectCompileError(t, `a.b := 1`,


### PR DESCRIPTION
fixes #386 

I'm not sure this is the best solution to the problem, but it's fairly minimal. I can't really think of anything other than functions that might need this recursive definition.

@d5 thoughts?