### PR TITLE
fix: do not invert token.Less to token.Greater in compiler

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -141,25 +141,7 @@ func (c *Compiler) Compile(node parser.Node) error {
 		if node.Token == token.LAnd || node.Token == token.LOr {
 			return c.compileLogical(node)
 		}
-		if node.Token == token.Less {
-			if err := c.Compile(node.RHS); err != nil {
-				return err
-			}
-			if err := c.Compile(node.LHS); err != nil {
-				return err
-			}
-			c.emit(node, parser.OpBinaryOp, int(token.Greater))
-			return nil
-		} else if node.Token == token.LessEq {
-			if err := c.Compile(node.RHS); err != nil {
-				return err
-			}
-			if err := c.Compile(node.LHS); err != nil {
-				return err
-			}
-			c.emit(node, parser.OpBinaryOp, int(token.GreaterEq))
-			return nil
-		}
+
 		if err := c.Compile(node.LHS); err != nil {
 			return err
 		}
@@ -182,6 +164,10 @@ func (c *Compiler) Compile(node parser.Node) error {
 			c.emit(node, parser.OpBinaryOp, int(token.Greater))
 		case token.GreaterEq:
 			c.emit(node, parser.OpBinaryOp, int(token.GreaterEq))
+		case token.Less:
+			c.emit(node, parser.OpBinaryOp, int(token.Less))
+		case token.LessEq:
+			c.emit(node, parser.OpBinaryOp, int(token.LessEq))
 		case token.Equal:
 			c.emit(node, parser.OpEqual)
 		case token.NotEqual:

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -107,12 +107,12 @@ func TestCompiler_Compile(t *testing.T) {
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 0),
 				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpBinaryOp, 39),
+				tengo.MakeInstruction(parser.OpBinaryOp, 38),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
-				intObject(2),
-				intObject(1))))
+				intObject(1),
+				intObject(2))))
 
 	expectCompile(t, `1 >= 2`,
 		bytecode(
@@ -131,12 +131,12 @@ func TestCompiler_Compile(t *testing.T) {
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 0),
 				tengo.MakeInstruction(parser.OpConstant, 1),
-				tengo.MakeInstruction(parser.OpBinaryOp, 44),
+				tengo.MakeInstruction(parser.OpBinaryOp, 43),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(
-				intObject(2),
-				intObject(1))))
+				intObject(1),
+				intObject(2))))
 
 	expectCompile(t, `1 == 2`,
 		bytecode(
@@ -929,9 +929,9 @@ func() {
 			concatInsts(
 				tengo.MakeInstruction(parser.OpConstant, 0),
 				tengo.MakeInstruction(parser.OpSetGlobal, 0),
-				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpBinaryOp, 39),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpBinaryOp, 38),
 				tengo.MakeInstruction(parser.OpJumpFalsy, 31),
 				tengo.MakeInstruction(parser.OpGetGlobal, 0),
 				tengo.MakeInstruction(parser.OpConstant, 2),
@@ -978,9 +978,9 @@ func() {
 				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpNotEqual),
 				tengo.MakeInstruction(parser.OpOrJump, 34),
-				tengo.MakeInstruction(parser.OpConstant, 1),
 				tengo.MakeInstruction(parser.OpGetGlobal, 0),
-				tengo.MakeInstruction(parser.OpBinaryOp, 39),
+				tengo.MakeInstruction(parser.OpConstant, 1),
+				tengo.MakeInstruction(parser.OpBinaryOp, 38),
 				tengo.MakeInstruction(parser.OpPop),
 				tengo.MakeInstruction(parser.OpSuspend)),
 			objectsArray(


### PR DESCRIPTION
I have posted an issue explaining this https://github.com/d5/tengo/issues/390