### PR TITLE
fix slice low/high index shadowing variables in vm

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -376,8 +376,8 @@ func (v *VM) run() {
 
 			var lowIdx int64
 			if low != UndefinedValue {
-				if low, ok := low.(*Int); ok {
-					lowIdx = low.Value
+				if lowInt, ok := low.(*Int); ok {
+					lowIdx = lowInt.Value
 				} else {
 					v.err = fmt.Errorf("invalid slice index type: %s",
 						low.TypeName())
@@ -391,8 +391,8 @@ func (v *VM) run() {
 				var highIdx int64
 				if high == UndefinedValue {
 					highIdx = numElements
-				} else if high, ok := high.(*Int); ok {
-					highIdx = high.Value
+				} else if highInt, ok := high.(*Int); ok {
+					highIdx = highInt.Value
 				} else {
 					v.err = fmt.Errorf("invalid slice index type: %s",
 						high.TypeName())
@@ -428,8 +428,8 @@ func (v *VM) run() {
 				var highIdx int64
 				if high == UndefinedValue {
 					highIdx = numElements
-				} else if high, ok := high.(*Int); ok {
-					highIdx = high.Value
+				} else if highInt, ok := high.(*Int); ok {
+					highIdx = highInt.Value
 				} else {
 					v.err = fmt.Errorf("invalid slice index type: %s",
 						high.TypeName())
@@ -465,8 +465,8 @@ func (v *VM) run() {
 				var highIdx int64
 				if high == UndefinedValue {
 					highIdx = numElements
-				} else if high, ok := high.(*Int); ok {
-					highIdx = high.Value
+				} else if highInt, ok := high.(*Int); ok {
+					highIdx = highInt.Value
 				} else {
 					v.err = fmt.Errorf("invalid slice index type: %s",
 						high.TypeName())
@@ -502,8 +502,8 @@ func (v *VM) run() {
 				var highIdx int64
 				if high == UndefinedValue {
 					highIdx = numElements
-				} else if high, ok := high.(*Int); ok {
-					highIdx = high.Value
+				} else if highInt, ok := high.(*Int); ok {
+					highIdx = highInt.Value
 				} else {
 					v.err = fmt.Errorf("invalid slice index type: %s",
 						high.TypeName())

--- a/vm_test.go
+++ b/vm_test.go
@@ -1090,6 +1090,15 @@ export func() {
 	b := 5
 	return b + "foo"
 }`), "Runtime Error: invalid operation: int + string\n\tat mod2:4:9")
+
+	expectError(t, `a := [1, 2, 3]; b := a[:"invalid"];`, nil,
+		"Runtime Error: invalid slice index type: string")
+	expectError(t, `a := immutable([4, 5, 6]); b := a[:false];`, nil,
+		"Runtime Error: invalid slice index type: bool")
+	expectError(t, `a := "hello"; b := a[:1.23];`, nil,
+		"Runtime Error: invalid slice index type: float")
+	expectError(t, `a := bytes("world"); b := a[:time(1)];`, nil,
+		"Runtime Error: invalid slice index type: time")
 }
 
 func TestVMErrorUnwrap(t *testing.T) {


### PR DESCRIPTION
Variables `low` and `high` are being shadowed. Therefore, when slice index is invalid (not an `integer`), the error message does not gives *correct* invalid type hint, and always return `Runtime Error: invalid slice index type: int`