### PR TITLE
Update objects.md to fix StringArray object injection example

### DIFF
--- a/docs/objects.md
+++ b/docs/objects.md
@@ -297,9 +297,11 @@ to add `StringArray` to the script:
 ```golang
 // script that uses 'my_list'
 s := tengo.NewScript([]byte(`
-    print(my_list + "three")
+    fmt := import("fmt")
+    fmt.println(my_list, ", three")
 `))
 
+s.SetImports(stdlib.GetModuleMap("fmt"))
 myList := &StringArray{Value: []string{"one", "two"}}
 s.Add("my_list", myList)  // add StringArray value 'my_list'
 s.Run()                   // prints "one, two, three"


### PR DESCRIPTION
Get example code to working state for StringArray object injection Just calling "print()" produces no output. Importing fmt and calling println() works. The output was also producing "one, twothree" instead of "one, two, three" as noted in the comment. This example code seems to have diverged from the implementation current at the time that it was written. This code now builds, executes, and produces the expected output for me.