### PR TITLE
Allow defining custom builtins

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -219,7 +219,7 @@ func runVM(
 
 	start := time.Now()
 
-	v := tengo.NewVM(bytecode, globals, -1)
+	v := tengo.NewVM(bytecode, nil, globals, -1)
 	if err := v.Run(); err != nil {
 		return time.Since(start), nil, err
 	}

--- a/cmd/tengo/main.go
+++ b/cmd/tengo/main.go
@@ -140,7 +140,7 @@ func CompileAndRun(
 		return
 	}
 
-	machine := tengo.NewVM(bytecode, nil, -1)
+	machine := tengo.NewVM(bytecode, nil, nil, -1)
 	err = machine.Run()
 	return
 }
@@ -153,7 +153,7 @@ func RunCompiled(modules *tengo.ModuleMap, data []byte) (err error) {
 		return
 	}
 
-	machine := tengo.NewVM(bytecode, nil, -1)
+	machine := tengo.NewVM(bytecode, nil, nil, -1)
 	err = machine.Run()
 	return
 }
@@ -213,7 +213,7 @@ func RunREPL(modules *tengo.ModuleMap, in io.Reader, out io.Writer) {
 		}
 
 		bytecode := c.Bytecode()
-		machine := tengo.NewVM(bytecode, globals, -1)
+		machine := tengo.NewVM(bytecode, nil, globals, -1)
 		if err := machine.Run(); err != nil {
 			_, _ = fmt.Fprintln(out, err.Error())
 			continue

--- a/script.go
+++ b/script.go
@@ -207,7 +207,7 @@ func (c *Compiled) Run() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	v := NewVM(c.bytecode, c.globals, c.maxAllocs)
+	v := NewVM(c.bytecode, nil, c.globals, c.maxAllocs)
 	return v.Run()
 }
 
@@ -216,7 +216,7 @@ func (c *Compiled) RunContext(ctx context.Context) (err error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	v := NewVM(c.bytecode, c.globals, c.maxAllocs)
+	v := NewVM(c.bytecode, nil, c.globals, c.maxAllocs)
 	ch := make(chan error, 1)
 	go func() {
 		defer func() {

--- a/vm.go
+++ b/vm.go
@@ -21,6 +21,7 @@ type VM struct {
 	constants   []Object
 	stack       [StackSize]Object
 	sp          int
+	builtins    []*BuiltinFunction
 	globals     []Object
 	fileSet     *parser.SourceFileSet
 	frames      [MaxFrames]frame
@@ -37,15 +38,20 @@ type VM struct {
 // NewVM creates a VM.
 func NewVM(
 	bytecode *Bytecode,
+	builtins []*BuiltinFunction,
 	globals []Object,
 	maxAllocs int64,
 ) *VM {
+	if builtins == nil {
+		builtins = GetAllBuiltinFunctions()
+	}
 	if globals == nil {
 		globals = make([]Object, GlobalsSize)
 	}
 	v := &VM{
 		constants:   bytecode.Constants,
 		sp:          0,
+		builtins:    builtins,
 		globals:     globals,
 		fileSet:     bytecode.FileSet,
 		framesIndex: 1,
@@ -739,7 +745,7 @@ func (v *VM) run() {
 		case parser.OpGetBuiltin:
 			v.ip++
 			builtinIndex := int(v.curInsts[v.ip])
-			v.stack[v.sp] = builtinFuncs[builtinIndex]
+			v.stack[v.sp] = v.builtins[builtinIndex]
 			v.sp++
 		case parser.OpClosure:
 			v.ip += 3

--- a/vm_test.go
+++ b/vm_test.go
@@ -3852,7 +3852,7 @@ func traceCompileRun(
 	trace = append(trace, fmt.Sprintf("\n[Compiled Instructions]\n\n%s\n",
 		strings.Join(bytecode.FormatInstructions(), "\n")))
 
-	v = tengo.NewVM(bytecode, globals, maxAllocs)
+	v = tengo.NewVM(bytecode, nil, globals, maxAllocs)
 
 	err = v.Run()
 	{


### PR DESCRIPTION
This is a feature I've found very helpful in my own project, SceneEngine.

For my use case, I've got custom user scripts being imported by a runtime script and I need to expose custom builtin functions to that userscript.
I tried creating the builtin as globals, but globals aren't exposed to libraries when they're imported.
