### PR TITLE
fix json.indent docs

### DIFF
--- a/docs/stdlib-json.md
+++ b/docs/stdlib-json.md
@@ -11,7 +11,7 @@ json := import("json")
 - `encode(o object) => bytes`: Returns the JSON string (bytes) of the object.
   Unlike Go's JSON package, this function does not HTML-escape texts, but, one
   can use `html_escape` function if needed.
-- `indent(b string/bytes) => bytes`: Returns an indented form of input JSON
+- `indent(b string/bytes, prefix string, indent string) => bytes`: Returns an indented form of input JSON
   bytes string.
 - `html_escape(b string/bytes) => bytes`: Return an HTML-safe form of input
   JSON bytes string.
@@ -22,7 +22,7 @@ json := import("json")
 json := import("json")
 
 encoded := json.encode({a: 1, b: [2, 3, 4]})  // JSON-encoded bytes string
-indentded := json.indent(encoded)             // indented form
+indentded := json.indent(encoded, "", "  ")   // indented form
 html_safe := json.html_escape(encoded)        // HTML escaped form
 
 decoded := json.decode(encoded)               // {a: 1, b: [2, 3, 4]}


### PR DESCRIPTION
Run the json module example in the Tengo playgroud giving the following error:

```
Runtime Error: wrong number of arguments in call to 'user-function:encode'
	at (main):7:13

------------------------
Version: 2.12.0
```

This PR fixes the json.indent docs.