### PR TITLE
Throw a runtime error when trying to slice an unsupported type

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -534,6 +534,8 @@ func (v *VM) run() {
 				}
 				v.stack[v.sp] = val
 				v.sp++
+			default:
+				v.err = fmt.Errorf("not indexable: %s", left.TypeName())
 			}
 		case parser.OpCall:
 			numArgs := int(v.curInsts[v.ip+1])

--- a/vm_test.go
+++ b/vm_test.go
@@ -3634,6 +3634,12 @@ func TestSpread(t *testing.T) {
 		"Runtime Error: wrong number of arguments: want=3, got=2")
 }
 
+func TestSliceIndex(t *testing.T) {
+	expectError(t, `undefined[:1]`, nil, "Runtime Error: not indexable")
+	expectError(t, `123[-1:2]`, nil, "Runtime Error: not indexable")
+	expectError(t, `{}[:]`, nil, "Runtime Error: not indexable")
+}
+
 func expectRun(
 	t *testing.T,
 	input string,


### PR DESCRIPTION
Add a missing switch case corresponding to a slice of an unsupported type. Without it Tengo continues execution past the unsupported slice with an invalid stack state, causing unexpected behaviour or obscure errors.

Example:

```golang
test := func() {
    a := 42
    return undefined[:5]
}

fmt := import("fmt")
fmt.println(test())  // -> prints 42
```

This PR changes it to throw a runtime error instead, which is consistent with similar cases such as using a function call operator on an unsupported type.