### PR TITLE
Fix: stop execution when trying to slice an unsupported type

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -536,6 +536,7 @@ func (v *VM) run() {
 				v.sp++
 			default:
 				v.err = fmt.Errorf("not indexable: %s", left.TypeName())
+				return
 			}
 		case parser.OpCall:
 			numArgs := int(v.curInsts[v.ip+1])

--- a/vm_test.go
+++ b/vm_test.go
@@ -3638,6 +3638,7 @@ func TestSliceIndex(t *testing.T) {
 	expectError(t, `undefined[:1]`, nil, "Runtime Error: not indexable")
 	expectError(t, `123[-1:2]`, nil, "Runtime Error: not indexable")
 	expectError(t, `{}[:]`, nil, "Runtime Error: not indexable")
+	expectError(t, `a := 123[-1:2] ; a += 1`, nil, "Runtime Error: not indexable")
 }
 
 func expectRun(


### PR DESCRIPTION
> This is a follow-up to https://github.com/d5/tengo/pull/442

Add a missing `return` to actually stop script execution after detecting an invalid slice operation. Otherwise the execution continues with an invalid stack causing unexpected behaviour:

```golang
a := 123[-1:2]
a += 1  // runtime error: index out of range [-1]
```