### PR TITLE
Allow builtin modules replacement in compiled scripts

### DIFF
--- a/bytecode.go
+++ b/bytecode.go
@@ -16,6 +16,11 @@ type Bytecode struct {
 	Constants    []Object
 }
 
+// Clone of the bytecode suitable for modification without affecting the original.
+// New Bytecode itself is independent, but all the contents of it are still shared
+// with the original.
+// The only thing that is not shared with the original is Constants slice, as it might be updated
+// by ReplaceBuiltinModule(), which should be safe for clone.
 func (b *Bytecode) Clone() *Bytecode {
 	return &Bytecode{
 		FileSet:      b.FileSet,

--- a/example_test.go
+++ b/example_test.go
@@ -44,3 +44,19 @@ each([a, b, c, d], func(x) {
 	// Output:
 	// 22 288
 }
+
+type TestModule struct {
+	value int
+}
+
+func (t *TestModule) module() *tengo.BuiltinModule {
+	return &tengo.BuiltinModule{
+		Attrs: map[string]tengo.Object{
+			"set": &tengo.UserFunction{Value: func(args ...tengo.Object) (tengo.Object, error) {
+				i, _ := tengo.ToInt64(args[0])
+				t.value = int(i)
+				return nil, nil
+			}},
+		},
+	}
+}

--- a/parser/source_file.go
+++ b/parser/source_file.go
@@ -26,7 +26,6 @@ func (p SourceFilePos) IsValid() bool {
 //	line                valid position without file name and no column (column == 0)
 //	file                invalid position with file name
 //	-                   invalid position without file name
-//
 func (p SourceFilePos) String() string {
 	s := p.Filename
 	if p.IsValid() {

--- a/script.go
+++ b/script.go
@@ -268,6 +268,11 @@ func (c *Compiled) Clone() *Compiled {
 	return clone
 }
 
+// ReplaceBuiltinModule replaces a builtin module with a new one.
+// This is helpful for concurrent script execution, when builtin module does not support
+// concurrency and you need to provide custom module instance for each script clone.
+//
+// Remember to call .Clone() to get an instance of the script safe for concurrent use.
 func (c *Compiled) ReplaceBuiltinModule(name string, attrs map[string]Object) {
 	c.lock.Lock()
 	defer c.lock.Unlock()


### PR DESCRIPTION
Motivation:

Compiled scripts can be executed concurrently out of the box.
At the same time, custom builtin modules can be passed to tengo script out from go, providing additional functionalities to the script.

If such builtin module is not designed for concurrent use, it becomes a limitation for the compiled tengo script. In most cases it is possible to 'rule out' concurrency use limitation on module's side, but in most cases this is 'fixed' by new lock introductions, which makes parallel tengo compiled scripts execution to block on single instance of builtin module during runtime.

For now, the only way to overcome this issue is to re-compile template for each instance of builtin module, which works well but leads to code overcomplication: it becomes necessary to manage compiled script pools in order to execute each script instance solely single-threaded because it is strictly bound to single builtin module instance.

This feature allows to hot-swap builtin module instance inside compiled script making it possible to execute several clones (`.Clone()`) in parallel, each using its own instance of builtin module.