### PR TITLE
Fix int == float always returning false

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -800,11 +800,13 @@ func (o *Float) IsFalsy() bool {
 // Equals returns true if the value of the type is equal to the value of
 // another object.
 func (o *Float) Equals(x Object) bool {
-	t, ok := x.(*Float)
-	if !ok {
-		return false
+	switch t := x.(type) {
+	case *Float:
+		return o.Value == t.Value
+	case *Int:
+		return o.Value == float64(t.Value)
 	}
-	return o.Value == t.Value
+	return false
 }
 
 // ImmutableArray represents an immutable array of objects.
@@ -1176,11 +1178,13 @@ func (o *Int) IsFalsy() bool {
 // Equals returns true if the value of the type is equal to the value of
 // another object.
 func (o *Int) Equals(x Object) bool {
-	t, ok := x.(*Int)
-	if !ok {
-		return false
+	switch t := x.(type) {
+	case *Int:
+		return o.Value == t.Value
+	case *Float:
+		return float64(o.Value) == t.Value
 	}
-	return o.Value == t.Value
+	return false
 }
 
 // Map represents a map of objects.

--- a/objects_test.go
+++ b/objects_test.go
@@ -683,6 +683,51 @@ func TestInt_BinaryOp(t *testing.T) {
 	}
 }
 
+func TestInt_Equals(t *testing.T) {
+	require.True(t, (&tengo.Int{Value: 1}).Equals(&tengo.Int{Value: 1}))
+	require.False(t, (&tengo.Int{Value: 1}).Equals(&tengo.Int{Value: 2}))
+
+	// int == float: must be consistent with BinaryOp cross-type ordering
+	require.True(t, (&tengo.Int{Value: 1}).Equals(&tengo.Float{Value: 1.0}))
+	require.False(t, (&tengo.Int{Value: 1}).Equals(&tengo.Float{Value: 1.5}))
+	require.True(t, (&tengo.Int{Value: 0}).Equals(&tengo.Float{Value: 0.0}))
+	require.False(t, (&tengo.Int{Value: 1}).Equals(&tengo.Float{Value: -1.0}))
+
+	// trichotomy: neither (a < b) nor (a > b) implies (a == b)
+	for l := int64(-2); l <= 2; l++ {
+		for r := float64(-2); r <= 2.1; r += 0.5 {
+			lt, _ := (&tengo.Int{Value: l}).BinaryOp(token.Less, &tengo.Float{Value: r})
+			gt, _ := (&tengo.Int{Value: l}).BinaryOp(token.Greater, &tengo.Float{Value: r})
+			if lt == tengo.FalseValue && gt == tengo.FalseValue {
+				require.True(t, (&tengo.Int{Value: l}).Equals(&tengo.Float{Value: r}),
+					"expected %d == %g", l, r)
+			}
+		}
+	}
+}
+
+func TestFloat_Equals(t *testing.T) {
+	require.True(t, (&tengo.Float{Value: 1.5}).Equals(&tengo.Float{Value: 1.5}))
+	require.False(t, (&tengo.Float{Value: 1.5}).Equals(&tengo.Float{Value: 2.5}))
+
+	// float == int: must be consistent with BinaryOp cross-type ordering
+	require.True(t, (&tengo.Float{Value: 1.0}).Equals(&tengo.Int{Value: 1}))
+	require.False(t, (&tengo.Float{Value: 1.5}).Equals(&tengo.Int{Value: 1}))
+	require.True(t, (&tengo.Float{Value: 0.0}).Equals(&tengo.Int{Value: 0}))
+
+	// trichotomy: neither (a < b) nor (a > b) implies (a == b)
+	for l := float64(-2); l <= 2.1; l += 0.5 {
+		for r := int64(-2); r <= 2; r++ {
+			lt, _ := (&tengo.Float{Value: l}).BinaryOp(token.Less, &tengo.Int{Value: r})
+			gt, _ := (&tengo.Float{Value: l}).BinaryOp(token.Greater, &tengo.Int{Value: r})
+			if lt == tengo.FalseValue && gt == tengo.FalseValue {
+				require.True(t, (&tengo.Float{Value: l}).Equals(&tengo.Int{Value: r}),
+					"expected %g == %d", l, r)
+			}
+		}
+	}
+}
+
 func TestMap_Index(t *testing.T) {
 	m := &tengo.Map{Value: make(map[string]tengo.Object)}
 	k := &tengo.Int{Value: 1}

--- a/vm_test.go
+++ b/vm_test.go
@@ -1029,6 +1029,14 @@ func TestEquality(t *testing.T) {
 	testEquality(t, `{a: 1, b: 2}`, `{b: 2}`, false)
 	testEquality(t, `{a: 1, b: {}}`, `{b: {}, a: 1}`, true)
 
+	// cross-type numeric equality must be consistent with ordering operators:
+	// if neither (a < b) nor (a > b) then (a == b) must hold
+	testEquality(t, `1`, `1.0`, true)
+	testEquality(t, `0`, `0.0`, true)
+	testEquality(t, `2`, `2.0`, true)
+	testEquality(t, `1`, `1.5`, false)
+	testEquality(t, `1`, `0.9`, false)
+
 	testEquality(t, `1`, `"foo"`, false)
 	testEquality(t, `1`, `true`, false)
 	testEquality(t, `[1]`, `["1"]`, false)


### PR DESCRIPTION
BinaryOp already handles cross-type int/float arithmetic and ordering, but Equals did strict type checks, so 1 == 1.0 returned false even though 1 < 1.0 and 1 > 1.0 were both false. Fixes issue #432.