### PR TITLE
Add freeze() builtin for deep immutability (#78)

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -125,6 +125,10 @@ var builtinFuncs = []*BuiltinFunction{
 		Name:  "range",
 		Value: builtinRange,
 	},
+	{
+		Name:  "freeze",
+		Value: builtinFreeze,
+	},
 }
 
 // GetAllBuiltinFunctions returns all builtin function objects.
@@ -677,4 +681,74 @@ func builtinSplice(args ...Object) (Object, error) {
 
 	// return deleted items
 	return &Array{Value: deleted}, nil
+}
+
+func builtinFreeze(args ...Object) (Object, error) {
+	if len(args) != 1 {
+		return nil, ErrWrongNumArguments
+	}
+	return freezeObject(args[0], make(map[Object]Object)), nil
+}
+
+// freezeObject recursively converts mutable containers to their immutable
+// equivalents. memo prevents infinite recursion on self-referential structures.
+func freezeObject(o Object, memo map[Object]Object) Object {
+	switch v := o.(type) {
+	case *Array:
+		if cached, ok := memo[o]; ok {
+			return cached
+		}
+		frozen := &ImmutableArray{Value: make([]Object, len(v.Value))}
+		memo[o] = frozen
+		for i, elem := range v.Value {
+			frozen.Value[i] = freezeObject(elem, memo)
+		}
+		return frozen
+
+	case *Map:
+		if cached, ok := memo[o]; ok {
+			return cached
+		}
+		frozen := &ImmutableMap{Value: make(map[string]Object, len(v.Value))}
+		memo[o] = frozen
+		for k, val := range v.Value {
+			frozen.Value[k] = freezeObject(val, memo)
+		}
+		return frozen
+
+	case *ImmutableArray:
+		// Re-freeze elements in case they contain mutable values.
+		newElems := make([]Object, len(v.Value))
+		changed := false
+		for i, elem := range v.Value {
+			f := freezeObject(elem, memo)
+			newElems[i] = f
+			if f != elem {
+				changed = true
+			}
+		}
+		if !changed {
+			return o
+		}
+		return &ImmutableArray{Value: newElems}
+
+	case *ImmutableMap:
+		newMap := make(map[string]Object, len(v.Value))
+		changed := false
+		for k, val := range v.Value {
+			f := freezeObject(val, memo)
+			newMap[k] = f
+			if f != val {
+				changed = true
+			}
+		}
+		if !changed {
+			return o
+		}
+		return &ImmutableMap{Value: newMap}
+
+	default:
+		// Primitives, strings, bytes, time, functions, errors — return as-is.
+		return o
+	}
 }

--- a/builtins_test.go
+++ b/builtins_test.go
@@ -504,3 +504,143 @@ func Test_builtinRange(t *testing.T) {
 		})
 	}
 }
+
+func TestBuiltinFreeze(t *testing.T) {
+	var freeze func(args ...tengo.Object) (tengo.Object, error)
+	for _, f := range tengo.GetAllBuiltinFunctions() {
+		if f.Name == "freeze" {
+			freeze = f.Value
+			break
+		}
+	}
+	if freeze == nil {
+		t.Fatal("builtin freeze not found")
+	}
+
+	t.Run("array becomes immutable array", func(t *testing.T) {
+		arr := &tengo.Array{Value: []tengo.Object{
+			&tengo.Int{Value: 1}, &tengo.Int{Value: 2},
+		}}
+		got, err := freeze(arr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ia, ok := got.(*tengo.ImmutableArray)
+		if !ok {
+			t.Fatalf("expected *ImmutableArray, got %T", got)
+		}
+		if len(ia.Value) != 2 || !reflect.DeepEqual(ia.Value[0], &tengo.Int{Value: 1}) {
+			t.Fatalf("unexpected value: %v", ia)
+		}
+	})
+
+	t.Run("map becomes immutable map", func(t *testing.T) {
+		m := &tengo.Map{Value: map[string]tengo.Object{
+			"x": &tengo.Int{Value: 42},
+		}}
+		got, err := freeze(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		im, ok := got.(*tengo.ImmutableMap)
+		if !ok {
+			t.Fatalf("expected *ImmutableMap, got %T", got)
+		}
+		if !reflect.DeepEqual(im.Value["x"], &tengo.Int{Value: 42}) {
+			t.Fatalf("unexpected value: %v", im)
+		}
+	})
+
+	t.Run("nested structures frozen recursively", func(t *testing.T) {
+		inner := &tengo.Array{Value: []tengo.Object{&tengo.Int{Value: 7}}}
+		outer := &tengo.Map{Value: map[string]tengo.Object{"inner": inner}}
+
+		got, err := freeze(outer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		im := got.(*tengo.ImmutableMap)
+		if _, ok := im.Value["inner"].(*tengo.ImmutableArray); !ok {
+			t.Fatalf("inner array not frozen, got %T", im.Value["inner"])
+		}
+	})
+
+	t.Run("already-immutable array with no mutable children returns same pointer", func(t *testing.T) {
+		ia := &tengo.ImmutableArray{Value: []tengo.Object{&tengo.Int{Value: 1}}}
+		got, err := freeze(ia)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != ia {
+			t.Fatal("expected same pointer for already-frozen array")
+		}
+	})
+
+	t.Run("already-immutable map with no mutable children returns same pointer", func(t *testing.T) {
+		im := &tengo.ImmutableMap{Value: map[string]tengo.Object{"a": &tengo.Int{Value: 1}}}
+		got, err := freeze(im)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != im {
+			t.Fatal("expected same pointer for already-frozen map")
+		}
+	})
+
+	t.Run("immutable array with mutable element is re-frozen", func(t *testing.T) {
+		inner := &tengo.Array{Value: []tengo.Object{&tengo.Int{Value: 5}}}
+		ia := &tengo.ImmutableArray{Value: []tengo.Object{inner}}
+		got, err := freeze(ia)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := got.(*tengo.ImmutableArray)
+		if result == ia {
+			t.Fatal("expected a new ImmutableArray since element was mutable")
+		}
+		if _, ok := result.Value[0].(*tengo.ImmutableArray); !ok {
+			t.Fatalf("inner element not frozen, got %T", result.Value[0])
+		}
+	})
+
+	t.Run("primitives pass through unchanged", func(t *testing.T) {
+		for _, obj := range []tengo.Object{
+			&tengo.Int{Value: 1},
+			&tengo.Float{Value: 3.14},
+			tengo.TrueValue,
+			&tengo.String{Value: "hello"},
+			tengo.UndefinedValue,
+		} {
+			got, err := freeze(obj)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != obj {
+				t.Fatalf("primitive %T was not returned as-is", obj)
+			}
+		}
+	})
+
+	t.Run("self-referential array does not infinite-loop", func(t *testing.T) {
+		arr := &tengo.Array{Value: []tengo.Object{&tengo.Int{Value: 1}}}
+		arr.Value = append(arr.Value, arr) // arr contains itself
+		got, err := freeze(arr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := got.(*tengo.ImmutableArray); !ok {
+			t.Fatalf("expected *ImmutableArray, got %T", got)
+		}
+	})
+
+	t.Run("wrong number of arguments", func(t *testing.T) {
+		_, err := freeze()
+		if err == nil {
+			t.Fatal("expected error for no arguments")
+		}
+		_, err = freeze(&tengo.Int{Value: 1}, &tengo.Int{Value: 2})
+		if err == nil {
+			t.Fatal("expected error for two arguments")
+		}
+	})
+}

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -323,3 +323,34 @@ immutable map, string, and bytes are iterable types in Tengo.
 ## is_time
 
 Returns `true` if the object's type is time. Or it returns `false`.
+## freeze
+
+Recursively converts a value into its fully immutable equivalent. Arrays
+become immutable arrays, maps become immutable maps, and all nested containers
+are converted in the same way. Primitives, strings, bytes, functions, and
+errors are returned as-is.
+
+If the input is already fully immutable (no mutable containers anywhere in the
+tree), the original value is returned without allocating anything new.
+
+```golang
+config := freeze({
+    limits: {max_retries: 3, timeout: 30},
+    tags:   ["prod", "v2"],
+})
+// config, config.limits, and config.tags are all immutable arrays/maps.
+is_immutable_map(config)          // true
+is_immutable_map(config.limits)   // true
+is_immutable_array(config.tags)   // true
+```
+
+`freeze` is particularly useful before sharing globals across concurrent
+`Clone()` executions: a frozen value is shared by all clones at zero copy
+cost because no clone can mutate it.
+
+```golang
+// Immutable input with no mutable children is returned as the same object.
+a := immutable([1, 2, 3])
+b := freeze(a)
+// b == a (same pointer, no allocation)
+```


### PR DESCRIPTION
freeze(x) recursively converts Arrays to ImmutableArrays and Maps to ImmutableMaps. Already-immutable values with no mutable children are returned as the same pointer (zero allocation). A memo table prevents infinite recursion on self-referential structures.

Primitives, strings, bytes, functions and errors pass through unchanged.

Closes the planned item from docs/freeze-builtin.md.