### PR TITLE
Add virtual filesystem support for module imports

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -55,6 +57,7 @@ type Compiler struct {
 	modules         ModuleGetter
 	compiledModules map[string]*CompiledFunction
 	allowFileImport bool
+	importFS        fs.FS
 	loops           []*loop
 	loopIndex       int
 	trace           io.Writer
@@ -526,7 +529,7 @@ func (c *Compiler) Compile(node parser.Node) error {
 			default:
 				panic(fmt.Errorf("invalid import value type: %T", v))
 			}
-		} else if c.allowFileImport {
+		} else if c.allowFileImport || c.importFS != nil {
 			moduleName := node.ModuleName
 
 			modulePath, err := c.getPathModule(moduleName)
@@ -535,7 +538,12 @@ func (c *Compiler) Compile(node parser.Node) error {
 					err.Error())
 			}
 
-			moduleSrc, err := ioutil.ReadFile(modulePath)
+			var moduleSrc []byte
+			if c.importFS != nil {
+				moduleSrc, err = fs.ReadFile(c.importFS, modulePath)
+			} else {
+				moduleSrc, err = ioutil.ReadFile(modulePath)
+			}
 			if err != nil {
 				return c.errorf(node, "module file read error: %s",
 					err.Error())
@@ -657,6 +665,14 @@ func (c *Compiler) SetImportFileExt(exts ...string) error {
 // local module files.
 func (c *Compiler) GetImportFileExt() []string {
 	return c.importFileExt
+}
+
+// SetImportFS sets a virtual filesystem for module loading. When set, import
+// statements resolve against this FS instead of the OS filesystem.
+// Setting an FS implicitly enables file-based imports; calling
+// EnableFileImport is not required.
+func (c *Compiler) SetImportFS(fsys fs.FS) {
+	c.importFS = fsys
 }
 
 func (c *Compiler) compileAssign(
@@ -1125,8 +1141,14 @@ func (c *Compiler) fork(
 	child.allowFileImport = c.allowFileImport
 	child.importDir = c.importDir
 	child.importFileExt = c.importFileExt
-	if isFile && c.importDir != "" {
-		child.importDir = filepath.Dir(modulePath)
+	child.importFS = c.importFS
+	if isFile {
+		if c.importFS != nil {
+			// VFS paths always use forward slashes; path.Dir is OS-agnostic.
+			child.importDir = path.Dir(modulePath)
+		} else if c.importDir != "" {
+			child.importDir = filepath.Dir(modulePath)
+		}
 	}
 	return child
 }
@@ -1321,6 +1343,17 @@ func (c *Compiler) getPathModule(moduleName string) (pathFile string, err error)
 
 		if !strings.HasSuffix(nameFile, ext) {
 			nameFile += ext
+		}
+
+		if c.importFS != nil {
+			// VFS path: always forward-slash, never rooted with '/'.
+			// path.Join("", "mod") == "mod"; path.Join("lib", "./mod") == "lib/mod".
+			resolved := path.Clean(path.Join(c.importDir, nameFile))
+			if _, serr := fs.Stat(c.importFS, resolved); serr == nil {
+				return resolved, nil
+			}
+			pathFile = resolved // keep for the error message below
+			continue
 		}
 
 		pathFile, err = filepath.Abs(filepath.Join(c.importDir, nameFile))

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/d5/tengo/v2
 
-go 1.13
+go 1.16

--- a/multifs.go
+++ b/multifs.go
@@ -1,0 +1,37 @@
+package tengo
+
+import (
+	"errors"
+	"io/fs"
+)
+
+// MultiFS is an fs.FS that tries each member filesystem in order.
+// Open returns the first successful result. A non-ErrNotExist error from any
+// member stops the search immediately and is returned to the caller.
+//
+// It is the idiomatic way to layer multiple virtual filesystems when using
+// Script.SetImportFS:
+//
+//	s.SetImportFS(tengo.MultiFS{baseFS, userFS})
+//
+// Relative imports work correctly across members: the import directory context
+// is a plain string prefix that is FS-agnostic, so a module found in any
+// member can resolve its own relative imports across the full set.
+type MultiFS []fs.FS
+
+// Open implements fs.FS. Each member is tried in slice order; the first
+// successful Open wins. If every member returns fs.ErrNotExist the error is
+// wrapped in an fs.PathError for the requested name.
+func (m MultiFS) Open(name string) (fs.File, error) {
+	for _, fsys := range m {
+		f, err := fsys.Open(name)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			// Propagate genuine errors immediately.
+			return nil, err
+		}
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}

--- a/multifs_test.go
+++ b/multifs_test.go
@@ -1,0 +1,114 @@
+package tengo_test
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/d5/tengo/v2"
+	"github.com/d5/tengo/v2/require"
+)
+
+func TestMultiFS_Open(t *testing.T) {
+	fsA := fstest.MapFS{
+		"a.tengo": &fstest.MapFile{Data: []byte(`export "from-a"`)},
+	}
+	fsB := fstest.MapFS{
+		"b.tengo": &fstest.MapFile{Data: []byte(`export "from-b"`)},
+	}
+
+	mfs := tengo.MultiFS{fsA, fsB}
+
+	t.Run("finds file in first FS", func(t *testing.T) {
+		f, err := mfs.Open("a.tengo")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	})
+
+	t.Run("finds file in second FS", func(t *testing.T) {
+		f, err := mfs.Open("b.tengo")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	})
+
+	t.Run("first FS shadows second for same path", func(t *testing.T) {
+		overlap := tengo.MultiFS{
+			fstest.MapFS{"x.tengo": &fstest.MapFile{Data: []byte(`export "first"`)}},
+			fstest.MapFS{"x.tengo": &fstest.MapFile{Data: []byte(`export "second"`)}},
+		}
+		data, err := fs.ReadFile(overlap, "x.tengo")
+		require.NoError(t, err)
+		require.Equal(t, `export "first"`, string(data))
+	})
+
+	t.Run("missing file returns ErrNotExist", func(t *testing.T) {
+		_, err := mfs.Open("missing.tengo")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+
+	t.Run("non-ErrNotExist error stops search immediately", func(t *testing.T) {
+		// errFS always returns a sentinel error that is not ErrNotExist.
+		// We place it first so that MultiFS must stop rather than try fsB.
+		sentinel := errors.New("storage unavailable")
+		errFS := errorFS{err: sentinel}
+		layered := tengo.MultiFS{errFS, fsB}
+		_, err := layered.Open("b.tengo")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sentinel))
+		// b.tengo exists in fsB but must never be reached.
+		require.False(t, errors.Is(err, fs.ErrNotExist))
+	})
+
+	t.Run("empty MultiFS returns ErrNotExist", func(t *testing.T) {
+		_, err := tengo.MultiFS{}.Open("any.tengo")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+}
+
+// errorFS is a test helper that always returns a fixed error from Open.
+type errorFS struct{ err error }
+
+func (e errorFS) Open(_ string) (fs.File, error) { return nil, e.err }
+
+func TestMultiFS_ScriptIntegration(t *testing.T) {
+	// Two independent FSes, each holding different modules.
+	fsA := fstest.MapFS{
+		"greet.tengo": &fstest.MapFile{
+			Data: []byte(`export func(name) { return "hello, " + name }`),
+		},
+	}
+	fsB := fstest.MapFS{
+		"math/add.tengo": &fstest.MapFile{
+			Data: []byte(`export func(a, b) { return a + b }`),
+		},
+		// Relative import: math/mul.tengo imports its sibling ./add.
+		"math/mul.tengo": &fstest.MapFile{
+			Data: []byte(`
+add := import("./add")
+export func(a, b) {
+    result := 0
+    for i := 0; i < b; i++ { result = add(result, a) }
+    return result
+}`),
+		},
+	}
+
+	s := tengo.NewScript([]byte(`
+greet   := import("greet")
+add     := import("math/add")
+mul     := import("math/mul")
+out_greet := greet("world")
+out_add   := add(3, 4)
+out_mul   := mul(6, 7)
+`))
+	s.SetImportFS(tengo.MultiFS{fsA, fsB})
+
+	compiled, err := s.Run()
+	require.NoError(t, err)
+	require.Equal(t, "hello, world", compiled.Get("out_greet").String())
+	require.Equal(t, 7, compiled.Get("out_add").Int())
+	require.Equal(t, 42, compiled.Get("out_mul").Int())
+}

--- a/script.go
+++ b/script.go
@@ -3,6 +3,7 @@ package tengo
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"sync"
 
@@ -18,6 +19,7 @@ type Script struct {
 	maxConstObjects  int
 	enableFileImport bool
 	importDir        string
+	importFS         fs.FS
 }
 
 // NewScript creates a Script instance with an input script.
@@ -87,6 +89,19 @@ func (s *Script) EnableFileImport(enable bool) {
 	s.enableFileImport = enable
 }
 
+// SetImportFS sets a virtual filesystem to use for module loading. When set,
+// import statements resolve against this FS instead of the OS filesystem,
+// making file imports available without touching the real disk.
+//
+// Use fs.Sub to root imports at a sub-directory of an existing FS:
+//
+//	s.SetImportFS(fs.Sub(myFS, "scripts"))
+//
+// When SetImportFS is used, calling EnableFileImport is not required.
+func (s *Script) SetImportFS(fsys fs.FS) {
+	s.importFS = fsys
+}
+
 // Compile compiles the script with all the defined variables, and, returns
 // Compiled object.
 func (s *Script) Compile() (*Compiled, error) {
@@ -106,6 +121,9 @@ func (s *Script) Compile() (*Compiled, error) {
 	c := NewCompiler(srcFile, symbolTable, nil, s.modules, nil)
 	c.EnableFileImport(s.enableFileImport)
 	c.SetImportDir(s.importDir)
+	if s.importFS != nil {
+		c.SetImportFS(s.importFS)
+	}
 	if err := c.Compile(file); err != nil {
 		return nil, err
 	}

--- a/script_test.go
+++ b/script_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/d5/tengo/v2"
@@ -664,4 +666,82 @@ data["b"] = 2
 
 	require.Equal(t, 1001, clone.Get("count").Int())
 	require.Equal(t, 2, len(clone.Get("data").Map()))
+}
+
+// TestScript_SetImportFS verifies that a virtual filesystem can be used to
+// resolve imports, including relative imports between modules.
+func TestScript_SetImportFS(t *testing.T) {
+	vfs := fstest.MapFS{
+		// top-level module
+		"greet.tengo": &fstest.MapFile{
+			Data: []byte(`export func(name) { return "hello, " + name }`),
+		},
+		// module in a subdirectory
+		"lib/math.tengo": &fstest.MapFile{
+			Data: []byte(`export func(a, b) { return a + b }`),
+		},
+		// module that imports a sibling via relative path
+		"lib/wrapper.tengo": &fstest.MapFile{
+			Data: []byte(`
+math := import("./math")
+export func(a, b) { return math(a, b) }
+`),
+		},
+	}
+
+	t.Run("absolute VFS import", func(t *testing.T) {
+		s := tengo.NewScript([]byte(`
+greet := import("greet")
+out := greet("world")
+`))
+		s.SetImportFS(vfs)
+		compiled, err := s.Run()
+		require.NoError(t, err)
+		require.Equal(t, "hello, world", compiled.Get("out").String())
+	})
+
+	t.Run("subdirectory VFS import", func(t *testing.T) {
+		s := tengo.NewScript([]byte(`
+add := import("lib/math")
+out := add(3, 4)
+`))
+		s.SetImportFS(vfs)
+		compiled, err := s.Run()
+		require.NoError(t, err)
+		require.Equal(t, 7, compiled.Get("out").Int())
+	})
+
+	t.Run("relative VFS import between modules", func(t *testing.T) {
+		s := tengo.NewScript([]byte(`
+wrapper := import("lib/wrapper")
+out := wrapper(10, 32)
+`))
+		s.SetImportFS(vfs)
+		compiled, err := s.Run()
+		require.NoError(t, err)
+		require.Equal(t, 42, compiled.Get("out").Int())
+	})
+
+	t.Run("module not found returns error", func(t *testing.T) {
+		s := tengo.NewScript([]byte(`x := import("missing")`))
+		s.SetImportFS(vfs)
+		_, err := s.Run()
+		require.Error(t, err)
+	})
+
+	t.Run("fs.Sub roots imports at subdirectory", func(t *testing.T) {
+		// fs.Sub(vfs, "lib") exposes lib/ as the FS root, so import("math")
+		// resolves to lib/math.tengo in the original tree.
+		libFS, subErr := fs.Sub(vfs, "lib")
+		require.NoError(t, subErr)
+
+		s := tengo.NewScript([]byte(`
+add := import("math")
+out := add(6, 7)
+`))
+		s.SetImportFS(libFS)
+		compiled, err := s.Run()
+		require.NoError(t, err)
+		require.Equal(t, 13, compiled.Get("out").Int())
+	})
 }


### PR DESCRIPTION
File-based imports currently require modules to exist on the OS filesystem. That makes Tengo harder to use in sandboxed environments, when embedding scripts into a binary, or when writing isolated unit tests without temporary files.

This changeset adds `SetImportFS(fsys fs.FS)` to both `Script` and `Compiler`. When set, imports are resolved and read through the provided `fs.FS` instead of the OS filesystem. Relative imports such as `import("./sibling")` are supported by tracking the current module directory as a forward-slash path, giving consistent behaviour across platforms.

The changeset also adds `MultiFS`, which layers multiple `fs.FS` values in priority order. This supports the common case where a base module archive needs to be partially overridden without changing import statements in scripts.

Because `fs.FS` is a standard library interface, this works out of the box with `embed.FS`, `testing/fstest.MapFS`, `fs.Sub`, and third-party filesystem adapters such as zip, tar, S3-backed filesystems, and similar implementations.

This requires raising the minimum supported Go version from 1.13 to 1.16. Given that Go 1.13 is now several years old, and Go 1.16 introduced useful standard-library support such as `io/fs`, I think this is a reasonable tradeoff.