### PR TITLE
Times lib: implement time.ISOWeek

### DIFF
--- a/docs/stdlib-times.md
+++ b/docs/stdlib-times.md
@@ -89,6 +89,7 @@ times := import("times")
 - `time_month(t time) => int`: returns the month of the year specified by t.
 - `time_day(t time) => int`: returns the day of the month specified by t.
 - `time_weekday(t time) => int`: returns the day of the week specified by t.
+- `time_isoweek(t time) => int`: returns the ISO 8601 week number specified by t, in the range [1,53].
 - `time_hour(t time) => int`: returns the hour within the day specified by t,
   in the range [0, 23].
 - `time_minute(t time) => int`: returns the minute offset within the hour

--- a/stdlib/times.go
+++ b/stdlib/times.go
@@ -132,6 +132,10 @@ var timesModule = map[string]tengo.Object{
 		Name:  "time_weekday",
 		Value: timesTimeWeekday,
 	}, // time_weekday(time) => int
+	"time_isoweek": &tengo.UserFunction{
+		Name:  "time_isoweek",
+		Value: timesTimeISOWeek,
+	}, // time_isoweek(time) => int
 	"time_hour": &tengo.UserFunction{
 		Name:  "time_hour",
 		Value: timesTimeHour,
@@ -873,6 +877,28 @@ func timesTimeWeekday(args ...tengo.Object) (ret tengo.Object, err error) {
 	}
 
 	ret = &tengo.Int{Value: int64(t1.Weekday())}
+
+	return
+}
+
+func timesTimeISOWeek(args ...tengo.Object) (ret tengo.Object, err error) {
+	if len(args) != 1 {
+		err = tengo.ErrWrongNumArguments
+		return
+	}
+
+	t1, ok := tengo.ToTime(args[0])
+	if !ok {
+		err = tengo.ErrInvalidArgumentType{
+			Name:     "first",
+			Expected: "time(compatible)",
+			Found:    args[0].TypeName(),
+		}
+		return
+	}
+
+	_, week := t1.ISOWeek()
+	ret = &tengo.Int{Value: int64(week)}
 
 	return
 }

--- a/stdlib/times_test.go
+++ b/stdlib/times_test.go
@@ -66,6 +66,8 @@ func TestTimes(t *testing.T) {
 	module(t, "times").call("before", time2, time2.Add(-time.Hour)).
 		expect(false)
 
+	_, isoweek := time1.ISOWeek()
+	module(t, "times").call("time_isoweek", time1).expect(isoweek)
 	module(t, "times").call("time_year", time1).expect(time1.Year())
 	module(t, "times").call("time_month", time1).expect(int(time1.Month()))
 	module(t, "times").call("time_day", time1).expect(time1.Day())


### PR DESCRIPTION
I think having time.ISOWeek available in Tengo would be useful. Implementing it within Tengo with the currently available functionality in the times lib, while not impossible, is cumbersome.

Open question: the Golang function time.ISOWeek() returns both a year and a week number. Currently, this PR only uses the week number, discarding the year completely. Is there a reason to also expose the returned year and if so, could/should that be done in the same function or in a separate one?