### PR TITLE
Reduce allocations in builtin range

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -1,5 +1,7 @@
 package tengo
 
+import "math"
+
 var builtinFuncs = []*BuiltinFunction{
 	{
 		Name:  "len",
@@ -337,63 +339,86 @@ func builtinRange(args ...Object) (Object, error) {
 	if numArgs < 2 || numArgs > 3 {
 		return nil, ErrWrongNumArguments
 	}
-	var start, stop, step *Int
-
-	for i, arg := range args {
-		v, ok := args[i].(*Int)
+	start, ok := args[0].(*Int)
+	if !ok {
+		return nil, ErrInvalidArgumentType{
+			Name:     "start",
+			Expected: "int",
+			Found:    args[0].TypeName(),
+		}
+	}
+	stop, ok := args[1].(*Int)
+	if !ok {
+		return nil, ErrInvalidArgumentType{
+			Name:     "stop",
+			Expected: "int",
+			Found:    args[1].TypeName(),
+		}
+	}
+	step := int64(1)
+	if numArgs == 3 {
+		v, ok := args[2].(*Int)
 		if !ok {
-			var name string
-			switch i {
-			case 0:
-				name = "start"
-			case 1:
-				name = "stop"
-			case 2:
-				name = "step"
-			}
-
 			return nil, ErrInvalidArgumentType{
-				Name:     name,
+				Name:     "step",
 				Expected: "int",
-				Found:    arg.TypeName(),
+				Found:    args[2].TypeName(),
 			}
 		}
-		if i == 2 && v.Value <= 0 {
+		if v.Value <= 0 {
 			return nil, ErrInvalidRangeStep
 		}
-		switch i {
-		case 0:
-			start = v
-		case 1:
-			stop = v
-		case 2:
-			step = v
-		}
+		step = v.Value
 	}
 
-	if step == nil {
-		step = &Int{Value: int64(1)}
+	n := rangeLen(start.Value, stop.Value, step)
+	if n > int64(MaxRangeLen) {
+		return nil, ErrRangeLimit
 	}
-
-	return buildRange(start.Value, stop.Value, step.Value), nil
+	return buildRange(start.Value, stop.Value, step, n), nil
 }
 
-func buildRange(start, stop, step int64) *Array {
-	array := &Array{}
+// rangeLen returns the number of integers in the sequence from start to stop
+// (exclusive) with the given positive step, counting downward when start >
+// stop. It uses unsigned math so a wide span does not overflow int64, and
+// saturates at math.MaxInt64.
+func rangeLen(start, stop, step int64) int64 {
+	var span uint64
 	if start <= stop {
-		for i := start; i < stop; i += step {
-			array.Value = append(array.Value, &Int{
-				Value: i,
-			})
-		}
+		span = uint64(stop) - uint64(start)
 	} else {
-		for i := start; i > stop; i -= step {
-			array.Value = append(array.Value, &Int{
-				Value: i,
-			})
-		}
+		span = uint64(start) - uint64(stop)
 	}
-	return array
+	ustep := uint64(step)
+	n := span / ustep
+	if span%ustep != 0 {
+		n++
+	}
+	if n > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(n)
+}
+
+// buildRange materializes the range as an array. n is the element count,
+// as returned by rangeLen(start, stop, step).
+func buildRange(start, stop, step, n int64) *Array {
+	if n == 0 {
+		return &Array{}
+	}
+	if start > stop {
+		step = -step
+	}
+	// One backing allocation for all Int elements.
+	ints := make([]Int, n)
+	elems := make([]Object, n)
+	v := start
+	for i := range ints {
+		ints[i].Value = v
+		elems[i] = &ints[i]
+		v += step
+	}
+	return &Array{Value: elems}
 }
 
 func builtinFormat(args ...Object) (Object, error) {

--- a/builtins_test.go
+++ b/builtins_test.go
@@ -2,6 +2,7 @@ package tengo_test
 
 import (
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 
@@ -484,6 +485,23 @@ func Test_builtinRange(t *testing.T) {
 				},
 			},
 		},
+		{name: "step larger than span does not overflow",
+			args:    []tengo.Object{intObject(0), intObject(10), intObject(math.MaxInt64 - 1)},
+			wantErr: false,
+			result: &tengo.Array{
+				Value: []tengo.Object{intObject(0)},
+			},
+		},
+		{name: "span overflows int64",
+			args:      []tengo.Object{intObject(math.MinInt64), intObject(math.MaxInt64)},
+			wantErr:   true,
+			wantedErr: tengo.ErrRangeLimit,
+		},
+		{name: "exceeds size limit",
+			args:      []tengo.Object{intObject(0), intObject(int64(tengo.MaxRangeLen) + 1)},
+			wantErr:   true,
+			wantedErr: tengo.ErrRangeLimit,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -500,6 +518,45 @@ func Test_builtinRange(t *testing.T) {
 			if tt.result != nil && !reflect.DeepEqual(tt.result, got) {
 				t.Errorf("builtinRange() arrays are not equal expected"+
 					" %s, got %s", tt.result, got.(*tengo.Array))
+			}
+		})
+	}
+}
+
+func Benchmark_builtinRange(b *testing.B) {
+	var builtinRange func(args ...tengo.Object) (tengo.Object, error)
+	for _, f := range tengo.GetAllBuiltinFunctions() {
+		if f.Name == "range" {
+			builtinRange = f.Value
+			break
+		}
+	}
+	if builtinRange == nil {
+		b.Fatal("builtin range not found")
+	}
+	benchmarks := []struct {
+		name string
+		args []tengo.Object
+	}{
+		{"asc-10", []tengo.Object{
+			&tengo.Int{Value: 0}, &tengo.Int{Value: 10}}},
+		{"asc-1000", []tengo.Object{
+			&tengo.Int{Value: 0}, &tengo.Int{Value: 1000}}},
+		{"asc-100000", []tengo.Object{
+			&tengo.Int{Value: 0}, &tengo.Int{Value: 100000}}},
+		{"asc-100000-step-10", []tengo.Object{
+			&tengo.Int{Value: 0}, &tengo.Int{Value: 100000},
+			&tengo.Int{Value: 10}}},
+		{"desc-1000", []tengo.Object{
+			&tengo.Int{Value: 1000}, &tengo.Int{Value: 0}}},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := builtinRange(bm.args...); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -354,3 +354,18 @@ a := immutable([1, 2, 3])
 b := freeze(a)
 // b == a (same pointer, no allocation)
 ```
+
+## range
+
+Returns an array of integers from start to stop (exclusive), moving by step.
+Step is optional and defaults to 1. Step must be greater than zero. The array
+descends when start is greater than stop.
+
+```golang
+a := range(0, 5)      // a == [0, 1, 2, 3, 4]
+b := range(5, 0)      // b == [5, 4, 3, 2, 1]
+c := range(0, 10, 3)  // c == [0, 3, 6, 9]
+```
+
+`range` builds the whole array in memory. A range with more than `MaxRangeLen`
+elements returns an error.

--- a/errors.go
+++ b/errors.go
@@ -52,6 +52,10 @@ var (
 
 	// ErrInvalidRangeStep is an error where the step parameter is less than or equal to 0 when using builtin range function.
 	ErrInvalidRangeStep = errors.New("range step must be greater than 0")
+
+	// ErrRangeLimit represents an error where a range has more elements than
+	// the builtin range function can materialize.
+	ErrRangeLimit = errors.New("exceeding range size limit")
 )
 
 // ErrInvalidArgumentType represents an invalid argument value type error.

--- a/tengo.go
+++ b/tengo.go
@@ -15,6 +15,13 @@ var (
 	// MaxBytesLen is the maximum length for bytes value. Note this limit
 	// applies to all compiler/VM instances in the process.
 	MaxBytesLen = 2147483647
+
+	// MaxRangeLen is the maximum number of elements the builtin range
+	// function materializes into an array. Larger ranges return
+	// ErrRangeLimit. Each element costs ~24 bytes (Object interface slot
+	// plus Int backing), so this cap bounds one range at ~240 MB. Note this
+	// limit applies to all compiler/VM instances in the process.
+	MaxRangeLen = 10000000
 )
 
 const (

--- a/vm_test.go
+++ b/vm_test.go
@@ -895,6 +895,18 @@ func TestBuiltinFunction(t *testing.T) {
 		out = [deleted, v]`, nil, ARR{ARR{"b"}, ARR{"a", "d", "e", "c"}})
 }
 
+func TestRangeN(t *testing.T) {
+	curMaxRangeLen := tengo.MaxRangeLen
+	defer func() { tengo.MaxRangeLen = curMaxRangeLen }()
+	tengo.MaxRangeLen = 10
+
+	expectRun(t, `out = len(range(0, 10))`, nil, 10)
+	expectError(t, `range(0, 11)`, nil, "range size limit")
+	// a wide step keeps the materialized range small
+	expectRun(t, `out = range(0, 10, 9223372036854775806)`, nil,
+		&tengo.Array{Value: []tengo.Object{&tengo.Int{Value: 0}}})
+}
+
 func TestBytesN(t *testing.T) {
 	curMaxBytesLen := tengo.MaxBytesLen
 	defer func() { tengo.MaxBytesLen = curMaxBytesLen }()


### PR DESCRIPTION
`range()` builds its result array with one `[]Int` backing slice and a
presized `[]Object`, so construction takes a small constant number of
allocations regardless of length, instead of one boxed `Int` per element plus
repeated slice growth.

It also computes the element count with overflow-safe unsigned math, and caps
materialization at a new `MaxRangeLen` (default 10,000,000; at ~24 bytes per element that bounds one
range at ~240 MB), returning `ErrRangeLimit` instead of a `makeslice` panic on an
oversized range.

### Benchmarks

`go test -bench . -benchmem`, measured per `Compiled.Run`, this branch vs `master`:

| scenario | master | this PR |
|---|---|---|
| `x := range(0, 1000000)` | 1000041 allocs / 96 MB | 5 / 24 MB |
| `for i in range(0, 100000) { s += i }` | 200031 / 10.6 MB | 100005 / 3.3 MB |
| `for _ in range(0, 1000000) {}` | 1000042 / 96 MB | 6 / 24 MB |

Construction drops from ~N allocations to a small constant at any length. The
allocations left in value-using loops are the loop-body arithmetic, not range
construction.

### Notes

- `range()` still returns a materialized array; value semantics are unchanged.
- The overflow-safe count also fixes wrong results for wide ranges, e.g.
  `range(0, 10, 9223372036854775806)` now yields `[0]` instead of an empty
  result.
- The `MaxRangeLen` cap is a behavior change at extreme sizes (an oversized
  `range()` returns an error instead of OOM/panic). Happy to split it into its
  own commit if you'd prefer to review it separately.

